### PR TITLE
v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.9.1] - 2026-09-04
+## [0.9.1] - 2026-09-05
 
 A dependency release, and the defects that adopting the dependency exposed.
 analyssa 0.6.0 reshapes how an exception clause is represented and takes away

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,124 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-09-04
+
+A dependency release, and the defects that adopting the dependency exposed.
+analyssa 0.6.0 reshapes how an exception clause is represented and takes away
+the CFG relations `SsaFunction` used to answer itself — which forced every
+analysis to say which graph it wanted, and three of them turned out to have been
+reading one that contains no handlers. The rest of the set shares that shape: an
+exception clause read through fields that could not say what the clause meant.
+
+### Fixed
+
+- **Liveness ran over a graph in which no handler is reachable.** The local
+  coalescer built its dataflow CFG from terminator edges alone, and nothing
+  branches to a handler entry — the runtime dispatches into it. A variable live
+  only across a protected region therefore came back dead, and the coalescer was
+  free to give its slot to something else. It now solves over the
+  exception-aware view; the extra edges only widen liveness, which is a
+  may-analysis, so nothing that was correct becomes wrong.
+
+- **SCCP folded values defined in handlers as constants nobody wrote.** The same
+  graph, the same reason, the opposite direction: constant propagation is rooted
+  at the entry and walks forward, so a handler block was simply never visited
+  and every value defined in one stayed at `Top` — the lattice element meaning
+  "no definition has reached this yet", which the fold reads as a constant. Both
+  SCCP rounds now run over the exception-aware view.
+
+- **A filter clause's handler body resolved to its filter expression.** The
+  decoder marks the filter's entry block and the handler body's entry block with
+  the same handler index, and the filter is laid out first, so the search that
+  took the first match answered with the filter block for every `catch … when`
+  clause — a wrong `handler_offset` in the regenerated exception table. The
+  filter is now resolved first and excluded from the handler's own search.
+
+- **Full inlining remapped only an operation's primary destination.** An
+  operation defining a secondary or flag output would have carried the callee's
+  variable id for it into the caller, where it means something else. Latent for
+  a CIL front-end, whose operations define one variable each, and repaired
+  rather than left to a future one: every definition the operand walk reports is
+  now remapped. That disagreement is why analyssa removed the
+  single-destination setter this used.
+
+- **One malformed PE resource discarded an assembly's entire metadata.** goblin
+  walks the resource directory in strict mode by default, so a single bad
+  `ResourceString` in a `VS_VERSIONINFO` block aborted the whole PE parse and
+  took every byte of CIL metadata with it. Nothing in dotscope reads that
+  directory — a .NET assembly's own resources live in the managed metadata — so
+  it is no longer parsed.
+
+- **CFF dispatcher detection counted a self-loop by hand.** It compensated for a
+  predecessor relation that dropped self-edges by scanning the block's
+  instructions for one. The relation it now asks reports a self-edge like any
+  other, so the compensation is gone and predecessor counts agree with what phi
+  validation sees.
+
+### Changed
+
+- **BREAKING**: **An exception clause is three optional block ranges, not five
+  loose block indices.** `SsaExceptionHandler` carries `protected_range`,
+  `handler_range` and `filter_range` — each a half-open `BlockRange` or nothing —
+  in place of `try_start_block`, `try_end_block`, `handler_start_block`,
+  `handler_end_block` and `filter_start_block`. A part can no longer be half of
+  itself: a region that began somewhere and ended nowhere was a state the old
+  five fields could hold and no check could refuse.
+
+  A CIL filter's extent is now recorded rather than inferred. It is
+  `[filter_offset, handler_offset)` — the blocks between the filter's entry and
+  the handler's — so a filter clause finally says where its expression is
+  instead of leaving every reader to guess it from the neighbouring parts.
+
+  `BlockRange`, `ClausePart`, `ClauseLayout`, `LaidOutHandler`, `HandlerKind`,
+  `ExceptionBlocks` and `ExceptionTableError` are re-exported from
+  `dotscope::analysis`, so a caller holding a dotscope exception handler has the
+  vocabulary it answers in without naming analyssa.
+
+- **BREAKING**: **`SsaBlock::terminator_op` is `SsaBlock::control_terminator`.**
+  The old name was positional — the block's last instruction, whatever it was —
+  while every call site was asking a control-flow question. The rename is
+  analyssa's; dotscope's call sites now ask the control question, so a block
+  whose last instruction is not a terminator contributes no edges rather than
+  edges leaving from an instruction control cannot reach.
+
+- **BREAKING**: **`SsaFunction` no longer answers predecessor or successor
+  questions.** `block_predecessors` and `block_successors` are gone;
+  `SsaCfg::from_ssa` is the terminator-derived relation and `EhCfg::from_ssa`
+  the exception-aware one, and which one an analysis needs is now a decision it
+  has to state.
+
+- **BREAKING**: **`SsaOp::Break` carries a `BreakpointOp`.** CIL `break` is
+  `SsaOp::Break(BreakpointOp::Breakpoint)`. `BreakpointOp` is re-exported from
+  `dotscope::analysis`.
+
+- **BREAKING**: **`ConstValue` gained a `Symbol` variant, so exhaustive matches
+  on it need one more arm.** CIL has no symbol space — every entity is named by
+  a metadata token that the type, method and field references already carry — so
+  `CilTarget::SymbolRef` is an uninhabited type and the arm is unreachable by
+  construction.
+
+- **`Target::handler_kind` replaces `Target::is_filter_handler`.** `CilTarget`
+  classifies through the existing `ExceptionHandlerFlags::kind`, so the
+  ECMA-335 §II.25.4.6 bit classification has one definition in the crate rather
+  than two that can disagree.
+
+- **UTF-16 and UTF-32 decoding takes the chunks as arrays.** Seven sites cut a
+  byte slice into fixed-width units by hand: six paired `chunks_exact(N)` with a
+  fallible conversion back to `[u8; N]`, and one indexed the chunk byte by byte.
+  Each carried a fallback for a case that cannot arise — a dropped code unit, a
+  zero, an error return. `as_chunks` yields the arrays themselves, so the
+  fallbacks and the bounds checks are gone with them.
+
+### Dependencies
+
+- `analyssa` 0.5.0 → 0.6.0
+- `quick-xml` 0.41.0 → 0.42.0. Element names and attribute keys are `&str`
+  rather than `&[u8]`, so `PermissionSet`'s XML reader compares them directly
+  instead of decoding each one and reporting a UTF-8 error the parser has
+  already ruled out.
+- `z3` 0.20.2 → 0.21.0
+
 ## [0.9.0] - 2026-08-15
 
 A security and correctness release. dotscope parses, emulates and rewrites

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,13 +20,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
 dependencies = [
  "cipher",
  "cpubits",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -99,9 +99,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "analyssa"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2879e5f80711226a2f0226ea504f34f6f13cdc983a64e4c5ab598c65884ebc4a"
+checksum = "8f9547a6316defcd8b3e6fcb49caaa7c93b27305a6c25824ae475e1461ea3660"
 dependencies = [
  "boxcar",
  "dashmap",
@@ -266,7 +266,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -336,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -533,7 +533,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -684,9 +684,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -712,7 +712,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5ef80386dea3cda50570f22e1c6a474f0cc688ae220fc584fef354acaf41f2b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "num-traits",
  "proc-macro2",
  "quote",
@@ -722,12 +722,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -814,7 +814,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -852,9 +852,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "cowfile"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59677f27c443ba67b4ee6af37659eaed4b7a1e68d28c4169167e550f17b8718e"
+checksum = "62c10f4a5e79d5e0a109ffeadb808578e24f82123292efd4c2412a21e9f9b4ff"
 dependencies = [
  "memmap2",
  "thiserror 2.0.20",
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1005,9 +1005,9 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1156,7 +1156,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
 ]
 
 [[package]]
@@ -1544,7 +1544,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1598,7 +1598,7 @@ dependencies = [
  "rustc-hash 2.1.3",
  "sha1 0.11.0",
  "sha2 0.11.0",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "strum 0.28.0",
  "tempfile",
  "thiserror 2.0.20",
@@ -1669,9 +1669,9 @@ checksum = "e1d926b4d407d372f141f93bb444696142c29d32962ccbd3531117cf3aa0bfa9"
 
 [[package]]
 name = "ecb"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbf3db731928d6912bc3beda911d55b834cee3df6131ba79b337a1298a3fa9"
+checksum = "26f2a8b3e564eba0877223dc343703ad0385794e882e6d13f3a4dd5c6b1f41ac"
 dependencies = [
  "cipher",
 ]
@@ -1684,9 +1684,9 @@ checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -1807,11 +1807,11 @@ dependencies = [
  "bit_field",
  "half",
  "lebe",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "num-complex",
  "pulp 0.22.3",
  "rayon-core",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "zune-inflate",
 ]
 
@@ -1866,18 +1866,19 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1928,7 +1929,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1964,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1979,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1989,15 +1990,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2006,38 +2007,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2390,9 +2391,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2400,7 +2401,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2478,9 +2479,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2580,9 +2581,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2608,9 +2609,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2622,7 +2623,7 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "tokio",
  "want",
 ]
@@ -2703,9 +2704,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2717,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2730,30 +2731,31 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2764,15 +2766,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2796,7 +2798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "utf8_iter",
 ]
 
@@ -2871,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
+checksum = "6e44b0a4eaa4c82f441d50a963f2d5f05a787240aeee097597033e72accfd22f"
 
 [[package]]
 name = "indexmap"
@@ -2888,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2948,9 +2950,9 @@ dependencies = [
 
 [[package]]
 name = "interprocess"
-version = "2.4.3"
+version = "2.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "798de1433ba514cc6c04c4144c2469af81396e4906195218737c776d47769572"
+checksum = "6cb02ffbf25e8ef0f4a95bff054eef75f6d1bf16919474cf2caa63b21997478a"
 dependencies = [
  "doctest-file",
  "libc",
@@ -3164,9 +3166,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3179,9 +3181,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -3191,13 +3193,13 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llguidance"
-version = "1.7.6"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a519d0a437a6cc433edf3db7df98db11fc860a1f57657b84913d51fc670570ff"
+checksum = "207e72ede15e79f1e7a7f0e2683387da031c1931f6de650020afb80c571efb67"
 dependencies = [
  "anyhow",
  "derivre",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "regex-syntax",
  "serde",
  "serde_json",
@@ -3215,9 +3217,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loop9"
@@ -3367,9 +3369,9 @@ dependencies = [
 
 [[package]]
 name = "memo-map"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+checksum = "5449c8c750f1a07ea702bbd212bd999fceece9b3d1508b17023b3e174583124b"
 
 [[package]]
 name = "metal"
@@ -3404,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja"
-version = "2.23.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d74234349a775546a83af0f0c0c0e3a73227dee4950a542cda81a47240b3e6"
+checksum = "86886cf6dbf4e614b19c9a1eec9775f021869d7eadde0fc73921a81b90c9b4c9"
 dependencies = [
  "memo-map",
  "serde",
@@ -3415,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "minijinja-contrib"
-version = "2.23.0"
+version = "2.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35c96d8fae7fa4743bbcf06f486ff43f81837f5e8826f8bf525dbc4c0e03be5d"
+checksum = "bd3e5f077bc2379f0f7d911e7cfdd921114ed99fc884533dca502944cb355b11"
 dependencies = [
  "minijinja",
  "serde",
@@ -3440,6 +3442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3453,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -3475,7 +3487,7 @@ dependencies = [
  "either",
  "futures",
  "image",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "mistralrs-core",
  "mistralrs-macros",
  "rand 0.9.5",
@@ -3539,7 +3551,7 @@ dependencies = [
  "html2text",
  "http",
  "image",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "indicatif 0.18.6",
  "interprocess",
  "itertools 0.14.0",
@@ -3595,7 +3607,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
- "uuid 1.24.0",
+ "uuid 1.26.0",
  "variantly",
  "vob",
 ]
@@ -3630,7 +3642,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "utoipa",
- "uuid 1.24.0",
+ "uuid 1.26.0",
 ]
 
 [[package]]
@@ -3734,7 +3746,7 @@ dependencies = [
  "num-complex",
  "num-rational",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rand_distr 0.4.3",
  "simba",
  "typenum",
@@ -3752,7 +3764,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
 ]
 
 [[package]]
@@ -3888,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -4114,9 +4126,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]
@@ -4183,7 +4195,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "windows-link 0.2.1",
 ]
 
@@ -4282,9 +4294,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -4330,7 +4342,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -4341,18 +4353,18 @@ checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+checksum = "10ab3eb7f3becc3a1cbc4f2c6f20267996cfc1a6467a873763411b136a122715"
 dependencies = [
  "portable-atomic",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -4497,9 +4509,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -4526,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -4594,9 +4606,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4675,7 +4687,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -4854,22 +4866,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5158,9 +5170,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -5226,7 +5238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e1aee7486406df3541b5a657204a11be97175a467d77bc98e6d94a66289fb80"
 dependencies = [
  "arraydeque",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 2.0.0-alpha.13",
  "thiserror 2.0.20",
 ]
 
@@ -5273,7 +5285,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5308,13 +5320,13 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
+checksum = "e1a36a382ed65dbcc0ab47fd5e9a94112417ccd34560a392ef3b7b0f0ec39148"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5356,7 +5368,7 @@ dependencies = [
  "precomputed-hash",
  "rustc-hash 2.1.3",
  "servo_arc",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
 ]
 
 [[package]]
@@ -5406,7 +5418,7 @@ dependencies = [
  "saphyr-parser-bw",
  "serde",
  "serde_json",
- "smallvec 2.0.0-alpha.12",
+ "smallvec 2.0.0-alpha.13",
  "zmij",
 ]
 
@@ -5427,7 +5439,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5438,7 +5450,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5447,7 +5459,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -5496,7 +5508,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -5545,7 +5557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5567,7 +5579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -5675,15 +5687,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smallvec"
-version = "2.0.0-alpha.12"
+version = "2.0.0-alpha.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef784004ca8777809dcdad6ac37629f0a97caee4c685fcea805278d81dd8b857"
+checksum = "ce56585dbefaf71c9723e9a269fa65227bdcdbb6fd2f3ef50d264c65e067c648"
 
 [[package]]
 name = "socket2"
@@ -5750,7 +5762,7 @@ dependencies = [
  "approx",
  "nalgebra",
  "num-traits",
- "rand 0.8.7",
+ "rand 0.8.8",
 ]
 
 [[package]]
@@ -6011,9 +6023,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6169,7 +6181,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6227,9 +6239,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6247,9 +6259,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6334,7 +6346,7 @@ checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.2",
+ "mio 1.2.3",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -6351,7 +6363,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -6366,9 +6378,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",
@@ -6402,9 +6414,9 @@ dependencies = [
 
 [[package]]
 name = "toktrie"
-version = "1.7.6"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "472bdd1540b864dc5654fd49ab2f9182ceb2112b9c0d3710a04136bacca30d4f"
+checksum = "16197572e4d4061591596b3629f587a1d7ac5858948c2097310cbb188da100b5"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -6415,9 +6427,9 @@ dependencies = [
 
 [[package]]
 name = "toktrie_hf_tokenizers"
-version = "1.7.6"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d198ef73712282678d05249ad65b0a011fcad7996caa26d70978e13ea513fe81"
+checksum = "f553ca5643b97203fca50b8f6e51d7384907f359becd59d311fe687127488435"
 dependencies = [
  "anyhow",
  "log",
@@ -6433,7 +6445,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -6466,7 +6478,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -6597,7 +6609,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -6714,7 +6726,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
- "smallvec 1.15.2",
+ "smallvec 1.16.0",
 ]
 
 [[package]]
@@ -6808,7 +6820,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6836,9 +6848,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -7532,9 +7544,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "y4m"
@@ -7597,9 +7609,9 @@ dependencies = [
 
 [[package]]
 name = "z3"
-version = "0.20.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c4de445f5c9e3013703a6b8a40c80b4a64c925f0a19e7d0a23a7a9b70e854d"
+checksum = "08975512fd325de2a15eede8ed293b2189c745e0770886fae2b30ae229c5b886"
 dependencies = [
  "log",
  "z3-sys",
@@ -7607,9 +7619,9 @@ dependencies = [
 
 [[package]]
 name = "z3-sys"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18b0a91a13522d21b3414847667de2b2056a721a3edcb5b6ee6858352d58db4"
+checksum = "96975839f50a909f6ec19671e5c06d7f0d6fc67287a120e1b010c5f8d91944d6"
 dependencies = [
  "pkg-config",
 ]
@@ -7663,9 +7675,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke 0.8.3",
@@ -7674,9 +7686,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke 0.8.3",
  "zerofrom",
@@ -7685,13 +7697,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -7701,10 +7713,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
  "crc32fast",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "memchr",
  "typed-path",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,7 +1564,7 @@ dependencies = [
 
 [[package]]
 name = "dotscope"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes",
  "analyssa",
@@ -1610,7 +1610,7 @@ dependencies = [
 
 [[package]]
 name = "dotscope-cli"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/dotscope-cli/Cargo.toml
+++ b/dotscope-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotscope-cli"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/dotscope/Cargo.toml
+++ b/dotscope/Cargo.toml
@@ -66,14 +66,14 @@ rayon = "1.12.0"
 rustc-hash = "2.1.3"
 smallvec = "1.15"
 boxcar = "0.2.14"
-quick-xml = "0.41.0"
+quick-xml = "0.42.0"
 hex = "0.4.3"
 num-bigint = { version = "0.5.1", optional = true }
 log = "0.4.33"
 flate2 = "1.1.9"
-analyssa = "0.5.0"
+analyssa = "0.6.0"
 lzma-rs = "0.3.0"
-z3 = { version = "0.20.2", optional = true }
+z3 = { version = "0.21.0", optional = true }
 iced-x86 = { version = "1.21.0", default-features = false, features = ["std", "decoder", "instr_info"], optional = true }
 tokio = { version = "1.53.1", optional = true, features = ["rt-multi-thread"] }
 

--- a/dotscope/Cargo.toml
+++ b/dotscope/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dotscope"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "A high-performance, cross-platform framework for analyzing and reverse engineering .NET PE executables"

--- a/dotscope/fuzz/Cargo.lock
+++ b/dotscope/fuzz/Cargo.lock
@@ -27,7 +27,9 @@ checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "analyssa"
-version = "0.5.0"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f9547a6316defcd8b3e6fcb49caaa7c93b27305a6c25824ae475e1461ea3660"
 dependencies = [
  "boxcar",
  "dashmap",
@@ -296,7 +298,7 @@ dependencies = [
 
 [[package]]
 name = "dotscope"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "aes",
  "analyssa",
@@ -598,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lzma-rs"
@@ -799,9 +801,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]
@@ -1346,59 +1348,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[patch.unused]]
-name = "analysir"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "autoit-rs"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "darwinscope"
-version = "0.1.1"
-
-[[patch.unused]]
-name = "gobin"
-version = "0.4.1"
-
-[[patch.unused]]
-name = "innospect"
-version = "0.1.3"
-
-[[patch.unused]]
-name = "mallabel"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "nimrod"
-version = "0.3.1"
-
-[[patch.unused]]
-name = "nsis"
-version = "0.3.1"
-
-[[patch.unused]]
-name = "pascalscript"
-version = "0.1.2"
-
-[[patch.unused]]
-name = "securs-fleet"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "securs-spec"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "securs-wg"
-version = "0.1.0"
-
-[[patch.unused]]
-name = "undelphi"
-version = "0.3.2"
-
-[[patch.unused]]
-name = "visualbasic"
-version = "0.3.1"

--- a/dotscope/src/analysis/cfg/semantics.rs
+++ b/dotscope/src/analysis/cfg/semantics.rs
@@ -336,7 +336,7 @@ impl<'a, T: Target> SemanticAnalyzer<'a, T> {
 
         // Dispatcher (switch with many targets that loop back)
         if has_switch {
-            if let Some(SsaOp::Switch { targets, .. }) = block.terminator_op() {
+            if let Some(SsaOp::Switch { targets, .. }) = block.control_terminator() {
                 if targets.len() >= 4 {
                     semantics.role = BlockRole::Dispatcher;
                     semantics.confidence = 0.8;
@@ -605,7 +605,7 @@ impl<'a, T: Target> SemanticAnalyzer<'a, T> {
         // Start from condition block's true target if it's a body block
         if let Some(cond) = loop_info.find_condition_in_body(self.ssa) {
             if let Some(block) = self.ssa.block(cond.index()) {
-                if let Some(SsaOp::Branch { true_target, .. }) = block.terminator_op() {
+                if let Some(SsaOp::Branch { true_target, .. }) = block.control_terminator() {
                     if *true_target < block_count && body_set.contains(*true_target) {
                         self.dfs_order(*true_target, &body_set, &mut visited, &mut ordered);
                     }
@@ -640,7 +640,7 @@ impl<'a, T: Target> SemanticAnalyzer<'a, T> {
 
         // Follow successors that are in the allowed set
         if let Some(b) = self.ssa.block(block) {
-            if let Some(op) = b.terminator_op() {
+            if let Some(op) = b.control_terminator() {
                 for succ in op.successors() {
                     self.dfs_order(succ, allowed, visited, order);
                 }

--- a/dotscope/src/analysis/mod.rs
+++ b/dotscope/src/analysis/mod.rs
@@ -108,14 +108,16 @@ pub(crate) use ssa::conv_op_for_target;
 pub use ssa::Z3Solver;
 pub use ssa::{
     address, pointsto, resolve_corelib_valuetype, AbstractValue, AliasResult, ArrayIndex,
-    BinaryOpKind, CilTarget, CmpKind, ConstEvaluator, ConstValue, ConstValueCilExt, ControlFlow,
-    DefSite, EvaluatorMark, FieldRef, IndirectLocation, MemoryDefSite, MemoryLocation, MemoryOp,
-    MemoryPhi, MemoryPhiOperand, MemorySsa, MemorySsaStats, MemoryVersion, MethodPurity, MethodRef,
-    PhiAnalyzer, PhiNode, PhiOperand, ReturnInfo, SsaBlock, SsaCfg, SsaConverter, SsaEvaluator,
-    SsaExceptionHandler, SsaExceptionHandlerCilExt, SsaFunction, SsaFunctionBuilder,
-    SsaFunctionCilExt, SsaFunctionSemanticsExt, SsaInstruction, SsaOp, SsaOpCilExt, SsaType,
-    SsaVarId, SsaVariable, SymbolicEvaluator, SymbolicExpr, SymbolicOp, Target, TypeClass,
-    TypeContext, TypeProvider, TypeRef, UnaryOpKind, UseSite, ValueResolver, VariableOrigin,
+    BinaryOpKind, BlockRange, BreakpointOp, CilTarget, ClauseLayout, ClausePart, CmpKind,
+    ConstEvaluator, ConstValue, ConstValueCilExt, ControlFlow, DefSite, EhCfg, EvaluatorMark,
+    ExceptionBlocks, ExceptionTableError, FieldRef, HandlerKind, IndirectLocation, LaidOutHandler,
+    MemoryDefSite, MemoryLocation, MemoryOp, MemoryPhi, MemoryPhiOperand, MemorySsa,
+    MemorySsaStats, MemoryVersion, MethodPurity, MethodRef, PhiAnalyzer, PhiNode, PhiOperand,
+    ReturnInfo, SsaBlock, SsaCfg, SsaConverter, SsaEvaluator, SsaExceptionHandler,
+    SsaExceptionHandlerCilExt, SsaFunction, SsaFunctionBuilder, SsaFunctionCilExt,
+    SsaFunctionSemanticsExt, SsaInstruction, SsaOp, SsaOpCilExt, SsaType, SsaVarId, SsaVariable,
+    SymbolicEvaluator, SymbolicExpr, SymbolicOp, Target, TypeClass, TypeContext, TypeProvider,
+    TypeRef, UnaryOpKind, UseSite, ValueResolver, VariableOrigin,
 };
 pub use taint::{
     cff_taint_config, find_token_dependencies, PhiTaintMode, TaintAnalysis, TaintConfig,

--- a/dotscope/src/analysis/ssa/builder.rs
+++ b/dotscope/src/analysis/ssa/builder.rs
@@ -1008,7 +1008,10 @@ mod tests {
 
         // Verify block 0 has branch
         let block0 = ssa.block(0).unwrap();
-        assert!(matches!(block0.terminator_op(), Some(SsaOp::Branch { .. })));
+        assert!(matches!(
+            block0.control_terminator(),
+            Some(SsaOp::Branch { .. })
+        ));
     }
 
     #[test]
@@ -1048,7 +1051,10 @@ mod tests {
 
         // Verify block 0 has switch
         let block0 = ssa.block(0).unwrap();
-        assert!(matches!(block0.terminator_op(), Some(SsaOp::Switch { .. })));
+        assert!(matches!(
+            block0.control_terminator(),
+            Some(SsaOp::Switch { .. })
+        ));
     }
 
     #[test]

--- a/dotscope/src/analysis/ssa/converter.rs
+++ b/dotscope/src/analysis/ssa/converter.rs
@@ -306,6 +306,8 @@ impl<'a, 'cfg> SsaConverter<'a, 'cfg> {
                 ConstValue::F64(_) => SsaType::F64,
                 ConstValue::String(_) | ConstValue::DecryptedString(_) => SsaType::String,
                 ConstValue::DecryptedArray { .. } => SsaType::Object,
+                // Uninhabited for this target: CIL has no symbol space.
+                ConstValue::Symbol(symbol) => match *symbol {},
                 // SIMD vector constant from the native substrate — no CIL type.
                 ConstValue::Vector(_) => SsaType::Unknown,
                 ConstValue::Null => SsaType::Null,
@@ -529,7 +531,7 @@ impl<'a, 'cfg> SsaConverter<'a, 'cfg> {
             | SsaOp::InitObj { .. }
             | SsaOp::CopyObj { .. }
             | SsaOp::Nop
-            | SsaOp::Break
+            | SsaOp::Break(_)
             | SsaOp::Constrained { .. }
             | SsaOp::Volatile
             | SsaOp::Unaligned { .. }
@@ -2974,7 +2976,7 @@ impl<'a, 'cfg> SsaConverter<'a, 'cfg> {
 
                     if let Some(block) = self.function.block_mut(block_idx) {
                         if let Some(instr) = block.instruction_mut(instr_idx) {
-                            instr.op_mut().set_dest(new_var);
+                            instr.op_mut().replace_def(sim_var, new_var);
                         }
                     }
                 }

--- a/dotscope/src/analysis/ssa/decompose.rs
+++ b/dotscope/src/analysis/ssa/decompose.rs
@@ -29,7 +29,7 @@
 use crate::{
     analysis::ssa::{
         conv_op_for_target,
-        ops::{CmpKind, SsaOp},
+        ops::{BreakpointOp, CmpKind, SsaOp},
         types::{FieldRef, MethodRef, SigRef, SsaType, TypeRef},
         value::ConstValue,
         SsaVarId,
@@ -1032,8 +1032,10 @@ fn decompose_standard_instruction(
         // =====================================================================
         // Misc
         // =====================================================================
-        0x00 => Some(SsaOp::Nop),   // nop
-        0x01 => Some(SsaOp::Break), // break
+        0x00 => Some(SsaOp::Nop), // nop
+        // CIL `break` is a debugger breakpoint, the same operation MIPS
+        // spells `break`.
+        0x01 => Some(SsaOp::Break(BreakpointOp::Breakpoint)),
 
         0x72 => {
             // ldstr
@@ -2468,7 +2470,7 @@ mod tests {
     fn test_decompose_break() {
         let instr = make_instruction(0x01, 0, "break", Operand::None, 0, 0);
         let op = decompose_instruction(&instr, &[], None, &[], None);
-        assert_eq!(op.unwrap(), SsaOp::Break);
+        assert_eq!(op.unwrap(), SsaOp::Break(BreakpointOp::Breakpoint));
     }
 
     #[test]

--- a/dotscope/src/analysis/ssa/exception.rs
+++ b/dotscope/src/analysis/ssa/exception.rs
@@ -5,6 +5,13 @@
 //! metadata types that analyssa doesn't see.
 
 use analyssa::ir::exception::SsaExceptionHandler as AnalyssaSsaExceptionHandler;
+// The vocabulary a clause is read in. Re-exported here so a caller reaching for
+// dotscope's `SsaExceptionHandler` finds the range, part and kind types it
+// answers in without also depending on analyssa by name.
+pub use analyssa::ir::exception::{
+    BlockRange, ClauseLayout, ClausePart, ExceptionBlocks, ExceptionTableError, HandlerKind,
+    LaidOutHandler,
+};
 
 use crate::{
     analysis::ssa::target::CilTarget,
@@ -41,11 +48,12 @@ pub fn from_exception_handler(handler: &ExceptionHandler) -> SsaExceptionHandler
         handler_offset: handler.handler_offset,
         handler_length: handler.handler_length,
         class_token_or_filter,
-        try_start_block: None,
-        try_end_block: None,
-        handler_start_block: None,
-        handler_end_block: None,
-        filter_start_block: None,
+        // Block ranges are established by SSA construction, which is the only
+        // place block indices exist; a clause built straight from the method
+        // body maps none of them yet.
+        protected_range: None,
+        handler_range: None,
+        filter_range: None,
     }
 }
 
@@ -68,141 +76,75 @@ impl SsaExceptionHandlerCilExt for AnalyssaSsaExceptionHandler<CilTarget> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metadata::method::ExceptionHandlerFlags;
+    use analyssa::ir::HandlerKind;
 
-    // Lock T to CilTarget for tests; they construct `SsaExceptionHandler` with
-    // CIL flags directly.
-    type SsaExceptionHandler = super::SsaExceptionHandler<CilTarget>;
-
-    #[test]
-    fn test_remap_block_indices_basic() {
-        let mut handler = SsaExceptionHandler {
-            flags: ExceptionHandlerFlags::EXCEPTION,
+    /// A method-body clause with the given flags and dual-purpose field.
+    ///
+    /// `handler` is left `None`, which is the state of every clause before type
+    /// resolution runs: `filter_offset` then carries the caught type's token for
+    /// an `EXCEPTION` clause and the filter's IL offset for a `FILTER` one, which
+    /// is precisely the ambiguity `from_exception_handler` resolves.
+    fn cil_handler(flags: ExceptionHandlerFlags, filter_offset: u32) -> ExceptionHandler {
+        ExceptionHandler {
+            flags,
             try_offset: 0,
             try_length: 10,
             handler_offset: 10,
             handler_length: 5,
-            class_token_or_filter: 0x01000001,
-            try_start_block: Some(0),
-            try_end_block: Some(2),
-            handler_start_block: Some(3),
-            handler_end_block: Some(4),
-            filter_start_block: None,
-        };
-
-        // Simulate block compaction: blocks 0, 2, 3, 4 kept; block 1 removed
-        // Old: [0, 1, 2, 3, 4] -> New: [0, -, 1, 2, 3]
-        let block_remap = vec![Some(0), None, Some(1), Some(2), Some(3)];
-
-        handler.remap_block_indices(&block_remap);
-
-        assert_eq!(handler.try_start_block, Some(0)); // 0 -> 0
-        assert_eq!(handler.try_end_block, Some(1)); // 2 -> 1
-        assert_eq!(handler.handler_start_block, Some(2)); // 3 -> 2
-        assert_eq!(handler.handler_end_block, Some(3)); // 4 -> 3
+            filter_offset,
+            handler: None,
+        }
     }
 
     #[test]
-    fn test_remap_block_indices_removed_block() {
-        let mut handler = SsaExceptionHandler {
-            flags: ExceptionHandlerFlags::EXCEPTION,
-            try_offset: 0,
-            try_length: 10,
-            handler_offset: 10,
-            handler_length: 5,
-            class_token_or_filter: 0x01000001,
-            try_start_block: Some(1), // This block will be removed
-            try_end_block: Some(2),
-            handler_start_block: Some(3),
-            handler_end_block: None,
-            filter_start_block: None,
-        };
+    fn from_exception_handler_maps_no_block_yet() {
+        let converted =
+            from_exception_handler(&cil_handler(ExceptionHandlerFlags::EXCEPTION, 0x0100_0001));
 
-        // Block 1 is removed
-        let block_remap = vec![Some(0), None, Some(1), Some(2)];
-
-        handler.remap_block_indices(&block_remap);
-
-        assert_eq!(handler.try_start_block, None); // Block was removed
-        assert_eq!(handler.try_end_block, Some(1)); // 2 -> 1
-        assert_eq!(handler.handler_start_block, Some(2)); // 3 -> 2
+        assert_eq!(converted.protected_range, None);
+        assert_eq!(converted.handler_range, None);
+        assert_eq!(converted.filter_range, None);
+        assert!(!converted.has_block_mapping());
     }
 
     #[test]
-    fn test_remap_block_indices_filter_handler() {
-        let mut handler = SsaExceptionHandler {
-            flags: ExceptionHandlerFlags::FILTER,
-            try_offset: 0,
-            try_length: 10,
-            handler_offset: 15,
-            handler_length: 5,
-            class_token_or_filter: 10, // Filter offset
-            try_start_block: Some(0),
-            try_end_block: Some(1),
-            handler_start_block: Some(3),
-            handler_end_block: Some(4),
-            filter_start_block: Some(2), // Filter block
-        };
+    fn catch_carries_its_class_token() {
+        let converted =
+            from_exception_handler(&cil_handler(ExceptionHandlerFlags::EXCEPTION, 0x0100_0001));
 
-        // All blocks shift by -1 except block 0
-        let block_remap = vec![Some(0), Some(1), Some(2), Some(3), Some(4)];
-
-        handler.remap_block_indices(&block_remap);
-
-        assert_eq!(handler.try_start_block, Some(0));
-        assert_eq!(handler.filter_start_block, Some(2));
-        assert_eq!(handler.handler_start_block, Some(3));
+        assert_eq!(converted.kind(), HandlerKind::Catch);
+        assert_eq!(converted.class_token(), Some(Token::new(0x0100_0001)));
+        assert_eq!(
+            converted.filter_offset(),
+            None,
+            "a catch clause has no filter offset to read"
+        );
     }
 
     #[test]
-    fn test_remap_end_block_finds_next_surviving() {
-        let mut handler = SsaExceptionHandler {
-            flags: ExceptionHandlerFlags::EXCEPTION,
-            try_offset: 0,
-            try_length: 10,
-            handler_offset: 10,
-            handler_length: 5,
-            class_token_or_filter: 0x01000001,
-            try_start_block: Some(0),
-            try_end_block: Some(2), // Block 2 is removed
-            handler_start_block: Some(3),
-            handler_end_block: Some(5), // Block 5 is removed
-            filter_start_block: None,
-        };
+    fn filter_carries_its_offset() {
+        let converted = from_exception_handler(&cil_handler(ExceptionHandlerFlags::FILTER, 0x20));
 
-        // Blocks 2 and 5 removed; next surviving after 2 is block 3 (new idx 1),
-        // next surviving after 5 is block 6 (new idx 3)
-        let block_remap = vec![Some(0), None, None, Some(1), None, None, Some(3)];
-
-        handler.remap_block_indices(&block_remap);
-
-        assert_eq!(handler.try_start_block, Some(0));
-        assert_eq!(handler.try_end_block, Some(1)); // Found next surviving (block 3 -> 1)
-        assert_eq!(handler.handler_start_block, Some(1));
-        assert_eq!(handler.handler_end_block, Some(3)); // Found next surviving (block 6 -> 3)
+        assert_eq!(converted.kind(), HandlerKind::Filter);
+        assert_eq!(converted.class_token(), None);
+        assert_eq!(converted.filter_offset(), Some(0x20));
     }
 
     #[test]
-    fn test_remap_end_block_none_when_no_surviving() {
-        let mut handler = SsaExceptionHandler {
-            flags: ExceptionHandlerFlags::EXCEPTION,
-            try_offset: 0,
-            try_length: 10,
-            handler_offset: 10,
-            handler_length: 5,
-            class_token_or_filter: 0x01000001,
-            try_start_block: Some(0),
-            try_end_block: Some(1),
-            handler_start_block: Some(2),
-            handler_end_block: Some(3), // Last block, removed, no surviving after it
-            filter_start_block: None,
-        };
+    fn finally_and_fault_are_neither() {
+        for (flags, expected) in [
+            (ExceptionHandlerFlags::FINALLY, HandlerKind::Finally),
+            (ExceptionHandlerFlags::FAULT, HandlerKind::Fault),
+        ] {
+            let converted = from_exception_handler(&cil_handler(flags, 0x20));
 
-        // Block 3 removed, nothing after it
-        let block_remap = vec![Some(0), Some(1), Some(2), None];
-
-        handler.remap_block_indices(&block_remap);
-
-        assert_eq!(handler.handler_end_block, None); // No surviving block after 3
+            assert_eq!(converted.kind(), expected);
+            assert_eq!(converted.class_token(), None);
+            assert_eq!(
+                converted.filter_offset(),
+                None,
+                "only a filter clause reads the dual-purpose field as an offset"
+            );
+        }
     }
 }

--- a/dotscope/src/analysis/ssa/mod.rs
+++ b/dotscope/src/analysis/ssa/mod.rs
@@ -98,9 +98,12 @@ pub use analyssa::ir::function::MethodPurity;
 pub(crate) use builder::conv_op_for_target;
 pub use builder::SsaFunctionBuilder;
 pub use converter::SsaConverter;
-pub use exception::{SsaExceptionHandler, SsaExceptionHandlerCilExt};
+pub use exception::{
+    BlockRange, ClauseLayout, ClausePart, ExceptionBlocks, ExceptionTableError, HandlerKind,
+    LaidOutHandler, SsaExceptionHandler, SsaExceptionHandlerCilExt,
+};
 pub use function::{SsaFunctionCilExt, SsaFunctionSemanticsExt};
-pub use ops::{BinaryOpKind, CmpKind, SsaOp, SsaOpCilExt, UnaryOpKind};
+pub use ops::{BinaryOpKind, BreakpointOp, CmpKind, SsaOp, SsaOpCilExt, UnaryOpKind};
 /// CIL-defaulted alias of [`analyssa::ir::function::SsaFunction`].
 pub type SsaFunction<T = CilTarget> = analyssa::ir::function::SsaFunction<T>;
 /// CIL-defaulted alias of [`analyssa::ir::function::ReturnInfo`].
@@ -141,6 +144,15 @@ pub type SsaInstruction<T = CilTarget> = analyssa::ir::instruction::SsaInstructi
 pub type SsaVariable<T = CilTarget> = analyssa::ir::variable::SsaVariable<T>;
 /// CIL-defaulted alias of [`analyssa::analysis::SsaCfg`].
 pub type SsaCfg<'a, T = CilTarget> = analyssa::analysis::cfg::SsaCfg<'a, T>;
+/// CIL-defaulted alias of [`analyssa::analysis::exceptions::EhCfg`].
+///
+/// The exception-aware flow view. `SsaCfg` carries only the edges a terminator
+/// takes, so a handler block is unreachable in it; this is the view rooted at
+/// handler and filter entries as well as the function entry, and the only one
+/// that implements `RootedGraph` and `DataFlowCfg`. Any solver-based or
+/// dominance-rooted analysis over CIL — which routinely carries protected
+/// regions — belongs here rather than on `SsaCfg`.
+pub type EhCfg<'a, T = CilTarget> = analyssa::analysis::exceptions::EhCfg<'a, T>;
 /// CIL-defaulted alias of [`analyssa::analysis::consts::ConstEvaluator`].
 pub type ConstEvaluator<'a, T = CilTarget> = analyssa::analysis::consts::ConstEvaluator<'a, T>;
 /// CIL-defaulted alias of [`analyssa::analysis::evaluator::SsaEvaluator`].

--- a/dotscope/src/analysis/ssa/ops.rs
+++ b/dotscope/src/analysis/ssa/ops.rs
@@ -8,7 +8,7 @@ use analyssa::ir::ops::SsaOp as AnalyssaSsaOp;
 // `BinaryOpInfo`/`UnaryOpInfo` aren't re-exported (the original dotscope
 // `ops.rs` didn't surface them either; direct callers go through
 // `analyssa::ir::ops` if they need them).
-pub use analyssa::ir::ops::{BinaryOpKind, CmpKind, UnaryOpKind};
+pub use analyssa::ir::ops::{BinaryOpKind, BreakpointOp, CmpKind, UnaryOpKind};
 
 use crate::{analysis::ssa::target::CilTarget, metadata::token::Token};
 

--- a/dotscope/src/analysis/ssa/target.rs
+++ b/dotscope/src/analysis/ssa/target.rs
@@ -12,15 +12,23 @@
 // Re-export so existing `crate::analysis::ssa::target::Target` import paths
 // in the rest of dotscope continue to resolve. The trait itself lives in
 // `analyssa::target`.
+use std::fmt;
+
 pub use analyssa::target::Target;
-use analyssa::{ir::value::ConstValue, PointerSize};
+use analyssa::{
+    ir::{value::ConstValue, HandlerKind},
+    PointerSize,
+};
 
 #[cfg(feature = "compiler")]
 use crate::compiler::CilCapability;
 use crate::{
     analysis::ssa::types::{FieldRef, MethodRef, SigRef, SsaType, TypeRef},
     assembly::{FlowType, Instruction, InstructionCategory, Operand, StackBehavior},
-    metadata::{method::ExceptionHandlerFlags, signatures::SignatureLocalVariable},
+    metadata::{
+        method::{ExceptionHandlerFlags, ExceptionHandlerKind},
+        signatures::SignatureLocalVariable,
+    },
 };
 
 /// `Target` impl for .NET CIL.
@@ -62,11 +70,29 @@ impl Default for CilTarget {
     }
 }
 
+/// The symbol space CIL does not have.
+///
+/// Every CIL entity is named by a metadata token, which the `TypeRef` /
+/// `MethodRef` / `FieldRef` references already carry — there is no separate
+/// space of addressable symbols to model. Declaring the associated type as an
+/// uninhabited enum states that: a `ConstValue::Symbol` cannot be constructed
+/// for this target at all, rather than merely being left unused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NoSymbol {}
+
+impl fmt::Display for NoSymbol {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Unreachable by construction: the type has no values.
+        match *self {}
+    }
+}
+
 impl Target for CilTarget {
     type TypeRef = TypeRef;
     type MethodRef = MethodRef;
     type FieldRef = FieldRef;
     type SigRef = SigRef;
+    type SymbolRef = NoSymbol;
     type ExceptionKind = ExceptionHandlerFlags;
     type Type = SsaType;
     type OriginalInstruction = Instruction;
@@ -149,8 +175,19 @@ impl Target for CilTarget {
         instr.rva
     }
 
-    fn is_filter_handler(flags: &Self::ExceptionKind) -> bool {
-        *flags == ExceptionHandlerFlags::FILTER
+    fn handler_kind(flags: &Self::ExceptionKind) -> HandlerKind {
+        // `ExceptionHandlerFlags::kind` already performs the ECMA-335 §II.25.4.6
+        // bitwise classification, so this arm only renames the four cases into
+        // analyssa's taxonomy. Going through it rather than comparing against
+        // the flag constants means a clause carrying an unrecognised bit is
+        // classified the same way every other CIL reader in the crate classifies
+        // it, instead of silently falling into a different default here.
+        match flags.kind() {
+            ExceptionHandlerKind::Catch => HandlerKind::Catch,
+            ExceptionHandlerKind::Filter => HandlerKind::Filter,
+            ExceptionHandlerKind::Finally => HandlerKind::Finally,
+            ExceptionHandlerKind::Fault => HandlerKind::Fault,
+        }
     }
 
     fn field_member_index(field: &Self::FieldRef) -> Option<u32> {
@@ -170,6 +207,8 @@ impl Target for CilTarget {
 
     fn result_type_for_const(value: &ConstValue<Self>) -> Option<Self::Type> {
         Some(match value {
+            // Uninhabited for this target: CIL has no symbol space.
+            ConstValue::Symbol(symbol) => match *symbol {},
             ConstValue::I8(_) => SsaType::I8,
             ConstValue::I16(_) => SsaType::I16,
             ConstValue::I32(_) => SsaType::I32,

--- a/dotscope/src/analysis/ssa/value.rs
+++ b/dotscope/src/analysis/ssa/value.rs
@@ -70,6 +70,8 @@ impl ConstValueCilExt for AnalyssaConstValue<CilTarget> {
             | AnalyssaConstValue::DecryptedString(_)
             | AnalyssaConstValue::Vector(_)
             | AnalyssaConstValue::DecryptedArray { .. } => SsaType::Object,
+            // Uninhabited for this target: CIL has no symbol space.
+            AnalyssaConstValue::Symbol(symbol) => match *symbol {},
         }
     }
 
@@ -94,6 +96,8 @@ impl TryFrom<&AnalyssaConstValue<CilTarget>> for Immediate {
     #[allow(clippy::cast_possible_wrap)] // Intentional bit-preserving casts for CIL semantics
     fn try_from(value: &AnalyssaConstValue<CilTarget>) -> Result<Self, Self::Error> {
         match value {
+            // Uninhabited for this target: CIL has no symbol space.
+            AnalyssaConstValue::Symbol(symbol) => match *symbol {},
             AnalyssaConstValue::I8(v) => Ok(Immediate::Int8(*v)),
             AnalyssaConstValue::I16(v) => Ok(Immediate::Int16(*v)),
             AnalyssaConstValue::I32(v) => Ok(Immediate::Int32(*v)),

--- a/dotscope/src/compiler/codegen/coalescing.rs
+++ b/dotscope/src/compiler/codegen/coalescing.rs
@@ -36,8 +36,8 @@ use rayon::prelude::*;
 
 use crate::{
     analysis::{
-        AnalysisResults, DataFlowSolver, LiveVariables, LivenessResult, SsaCfg, SsaFunction, SsaOp,
-        SsaType, SsaVarId, VariableOrigin,
+        AnalysisResults, DataFlowSolver, EhCfg, LiveVariables, LivenessResult, SsaCfg, SsaFunction,
+        SsaOp, SsaType, SsaVarId, VariableOrigin,
     },
     Error, Result,
 };
@@ -184,8 +184,14 @@ impl LocalCoalescer {
             interference.set_type(var.id(), var.var_type().clone());
         }
 
-        // Build CFG for dataflow analysis
-        let cfg = SsaCfg::from_ssa(ssa);
+        // Build CFG for dataflow analysis.
+        //
+        // The solver must run over the exception-aware view: a traversal seeded
+        // from terminator edges alone never reaches a handler block, so every
+        // variable live only across a protected region would come back dead.
+        // The extra edges only widen liveness, which is a may-analysis, so a
+        // value reported live across an exceptional edge is conservative.
+        let cfg = EhCfg::from_ssa(ssa);
 
         // Run liveness analysis
         let analysis = LiveVariables::new(ssa);

--- a/dotscope/src/compiler/codegen/mod.rs
+++ b/dotscope/src/compiler/codegen/mod.rs
@@ -55,14 +55,14 @@ fn crc32_hash(data: &[u8]) -> u32 {
 
 use crate::{
     analysis::{
-        CmpKind, ConstValue, SsaBlock, SsaFunction, SsaInstruction, SsaOp, SsaType, SsaVarId,
-        SsaVariable, VariableOrigin,
+        CmpKind, ConstValue, HandlerKind, SsaBlock, SsaExceptionHandler, SsaFunction,
+        SsaInstruction, SsaOp, SsaType, SsaVarId, SsaVariable, VariableOrigin,
     },
     assembly::{Immediate, InstructionEncoder, Operand},
     cilassembly::CilAssembly,
     compiler::codegen::coalescing::LocalCoalescer,
     metadata::{
-        method::{ExceptionHandler, ExceptionHandlerFlags},
+        method::ExceptionHandler,
         signatures::{
             encode_field_signature, CustomModifiers, SignatureField, SignatureLocalVariable,
             TypeSignature,
@@ -560,51 +560,41 @@ impl SsaCodeGenerator {
         let mut handlers = Vec::new();
 
         for eh in ssa.exception_handlers() {
+            let offset_of = |block: usize| self.block_offsets.get(&block).copied();
+
             let try_offset = eh
-                .try_start_block
-                .and_then(|b| self.block_offsets.get(&b).copied())
+                .protected_range
+                .and_then(|range| offset_of(range.start()))
                 .unwrap_or(eh.try_offset);
 
             let handler_offset = eh
-                .handler_start_block
-                .and_then(|b| self.block_offsets.get(&b).copied())
+                .handler_range
+                .and_then(|range| offset_of(range.start()))
                 .unwrap_or(eh.handler_offset);
 
             let try_end = eh
-                .try_end_block
-                .and_then(|b| self.block_offsets.get(&b).copied())
-                .or_else(|| {
-                    // If try_start has a valid mapping but try_end doesn't,
-                    // the try region extends to the handler start
-                    if eh.try_start_block.is_some() {
-                        Some(handler_offset)
-                    } else {
-                        None
-                    }
+                .protected_range
+                .and_then(|range| {
+                    // The exclusive end can be one past the last block, which has
+                    // no offset of its own; the try region then runs to wherever
+                    // the handler begins.
+                    offset_of(range.end()).or(Some(handler_offset))
                 })
                 .unwrap_or(eh.try_offset.saturating_add(eh.try_length));
 
             let handler_end = eh
-                .handler_end_block
-                .and_then(|b| self.block_offsets.get(&b).copied())
-                .or_else(|| {
-                    // If handler_start has a valid mapping but handler_end doesn't,
-                    // the handler extends to the end of bytecode
-                    if eh.handler_start_block.is_some() {
-                        Some(bytecode_len)
-                    } else {
-                        None
-                    }
+                .handler_range
+                .and_then(|range| {
+                    // Likewise: a handler ending with the method has no block
+                    // after it, so it extends to the end of the bytecode.
+                    offset_of(range.end()).or(Some(bytecode_len))
                 })
                 .unwrap_or(eh.handler_offset.saturating_add(eh.handler_length));
 
-            let filter_offset = if eh.flags == ExceptionHandlerFlags::FILTER {
-                eh.filter_start_block
-                    .and_then(|b| self.block_offsets.get(&b).copied())
-                    .unwrap_or(eh.class_token_or_filter)
-            } else {
-                eh.class_token_or_filter
-            };
+            let filter_offset = eh
+                .filter_range
+                .and_then(|range| offset_of(range.start()))
+                .unwrap_or(eh.class_token_or_filter);
 
             // Drop handlers with empty try or handler regions. This happens
             // legitimately when optimization eliminates the guarded code — the
@@ -786,21 +776,19 @@ impl SsaCodeGenerator {
         // Catch and filter handlers start with the exception object already on the stack.
         for handler in ssa.exception_handlers() {
             // Catch handler entry: exception object is on the stack (depth 1)
-            if let Some(handler_block) = handler.handler_start_block {
-                if handler.flags == ExceptionHandlerFlags::EXCEPTION
-                    || handler.flags == ExceptionHandlerFlags::FILTER
-                {
+            if let Some(handler_block) = handler.handler_range.map(|range| range.start()) {
+                if matches!(handler.kind(), HandlerKind::Catch | HandlerKind::Filter) {
                     if let Some(label) = self.block_labels.get(&handler_block) {
                         encoder.set_label_stack_depth(label, 1);
                     }
                 }
             }
-            // Filter block entry: exception object is on the stack (depth 1)
-            if let Some(filter_block) = handler.filter_start_block {
-                if handler.flags == ExceptionHandlerFlags::FILTER {
-                    if let Some(label) = self.block_labels.get(&filter_block) {
-                        encoder.set_label_stack_depth(label, 1);
-                    }
+            // Filter block entry: exception object is on the stack (depth 1).
+            // A filter range only exists on a filter clause, so its presence is
+            // the kind test.
+            if let Some(filter_block) = handler.filter_range.map(|range| range.start()) {
+                if let Some(label) = self.block_labels.get(&filter_block) {
+                    encoder.set_label_stack_depth(label, 1);
                 }
             }
         }
@@ -1362,16 +1350,17 @@ impl SsaCodeGenerator {
         // handler block before its try block, producing inverted byte offsets
         // (e.g. try=93..60) that violate ECMA-335 EH semantics.
         //
-        // For each handler_start_block, collect all try_start_blocks that must
+        // For each handler entry, collect the protected-region entries that must
         // precede it (a handler block may serve multiple EH regions).
         let mut handler_requires_try: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-        // Map try_start_block → handler_start_block for scheduling handlers
+        // Map protected-region entry → handler entry for scheduling handlers
         // after their try bodies.
         let mut try_to_handler: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
         for eh in ssa.exception_handlers() {
-            if let (Some(try_block), Some(handler_block)) =
-                (eh.try_start_block, eh.handler_start_block)
-            {
+            if let (Some(try_block), Some(handler_block)) = (
+                eh.protected_range.map(|range| range.start()),
+                eh.handler_range.map(|range| range.start()),
+            ) {
                 handler_requires_try
                     .entry(handler_block)
                     .or_default()
@@ -1388,7 +1377,7 @@ impl SsaCodeGenerator {
             .blocks()
             .iter()
             .filter_map(|b| {
-                if let Some(SsaOp::Leave { target }) = b.terminator_op() {
+                if let Some(SsaOp::Leave { target }) = b.control_terminator() {
                     Some(*target)
                 } else {
                     None
@@ -1403,9 +1392,10 @@ impl SsaCodeGenerator {
         // region, so we don't follow their targets.
         let mut eh_region_blocks: BTreeSet<usize> = BTreeSet::new();
         for eh in ssa.exception_handlers() {
-            let starts: Vec<usize> = [eh.try_start_block, eh.handler_start_block]
+            let starts: Vec<usize> = [eh.protected_range, eh.handler_range]
                 .into_iter()
                 .flatten()
+                .map(|range| range.start())
                 .collect();
             for start in starts {
                 let mut bfs_queue = vec![start];
@@ -1414,7 +1404,7 @@ impl SsaCodeGenerator {
                         continue;
                     }
                     if let Some(block) = ssa.block(b) {
-                        if let Some(term) = block.terminator_op() {
+                        if let Some(term) = block.control_terminator() {
                             // Only follow internal control flow. Leave exits the
                             // try region, EndFinally/EndFilter exit the handler,
                             // and Throw/Rethrow/Return exit everything.
@@ -1496,7 +1486,7 @@ impl SsaCodeGenerator {
                 // EndFinally/etc. which exit the region.
                 if eh_region_blocks.contains(&block_id) {
                     if let Some(block) = ssa.block(block_id) {
-                        if let Some(term) = block.terminator_op() {
+                        if let Some(term) = block.control_terminator() {
                             let targets: Vec<usize> = match term {
                                 SsaOp::Jump { target } => vec![*target],
                                 SsaOp::Branch {
@@ -1636,7 +1626,7 @@ impl SsaCodeGenerator {
 
             // Preferred successor first, matching `compute_block_layout::preferred_successor`,
             // so the edge block that can be reached by fall-through is the adjacent one.
-            let edge_targets: Vec<usize> = match block.terminator_op() {
+            let edge_targets: Vec<usize> = match block.control_terminator() {
                 Some(
                     SsaOp::Branch {
                         true_target,
@@ -1695,7 +1685,7 @@ impl SsaCodeGenerator {
         let handler_entry_blocks: BTreeSet<usize> = ssa
             .exception_handlers()
             .iter()
-            .filter_map(|h| h.handler_start_block)
+            .filter_map(|h| h.handler_range.map(|range| range.start()))
             .collect();
 
         // Phase 2: Pre-allocate all live phi results to local slots.
@@ -2724,9 +2714,11 @@ impl SsaCodeGenerator {
         // so that define_label resets the stack depth to the expected handler entry depth
         // (e.g., 1 for catch/filter) rather than conflicting with the previous block's
         // fallthrough depth.
-        let is_handler_entry = ssa.exception_handlers().iter().any(|h| {
-            h.handler_start_block == Some(block_idx) || h.filter_start_block == Some(block_idx)
-        });
+        let is_handler_entry = ssa
+            .exception_handlers()
+            .iter()
+            .flat_map(SsaExceptionHandler::entry_blocks)
+            .any(|entry| entry == block_idx);
         if is_handler_entry {
             encoder.mark_unreachable();
         }
@@ -2797,7 +2789,7 @@ impl SsaCodeGenerator {
             // mark as unreachable so the stack depth doesn't leak to the next block in the layout.
             // This is critical for empty exception handler entry blocks whose pre-set depth (1 for
             // catch/filter) would otherwise propagate incorrectly to unrelated successor blocks.
-            if block.terminator_op().is_none() {
+            if block.control_terminator().is_none() {
                 encoder.mark_unreachable();
             }
             return Ok(());
@@ -2813,16 +2805,16 @@ impl SsaCodeGenerator {
         // on the stack when execution enters the handler. Pop instructions that pop
         // this exception object should NOT try to load it first - it's already there.
         //
-        // We identify handler entry blocks by checking if this block is a handler_start_block
-        // for an EXCEPTION or FILTER handler.
+        // We identify handler entry blocks by checking if this block begins the
+        // handler range of a catch or filter clause.
         let is_exception_handler_entry = ssa.exception_handlers().iter().any(|h| {
-            h.handler_start_block == Some(block_idx)
-                && (h.flags == ExceptionHandlerFlags::EXCEPTION
-                    || h.flags == ExceptionHandlerFlags::FILTER)
+            h.handler_range.map(|range| range.start()) == Some(block_idx)
+                && matches!(h.kind(), HandlerKind::Catch | HandlerKind::Filter)
         });
-        let is_filter_entry = ssa.exception_handlers().iter().any(|h| {
-            h.filter_start_block == Some(block_idx) && h.flags == ExceptionHandlerFlags::FILTER
-        });
+        let is_filter_entry = ssa
+            .exception_handlers()
+            .iter()
+            .any(|h| h.filter_range.map(|range| range.start()) == Some(block_idx));
 
         if is_exception_handler_entry || is_filter_entry {
             // Clear operands for Pop instructions that consume the exception object.
@@ -3629,7 +3621,7 @@ impl SsaCodeGenerator {
                 encoder.emit_instruction("nop", None)?;
             }
 
-            SsaOp::Break => {
+            SsaOp::Break(_) => {
                 encoder.emit_instruction("break", None)?;
             }
 
@@ -4626,7 +4618,8 @@ impl SsaCodeGenerator {
             ConstValue::FieldHandle(field_ref) => {
                 encoder.emit_instruction("ldtoken", Some(Operand::Token(field_ref.token())))?;
             }
-
+            // Uninhabited for this target: CIL has no symbol space.
+            ConstValue::Symbol(symbol) => match *symbol {},
             // Decrypted arrays: emit newarr + individual element stores.
             // Decrypted arrays: emit newarr + InitializeArray using FieldRVA data.
             // Produces the same compact pattern as the C# compiler:

--- a/dotscope/src/compiler/codegen/tests.rs
+++ b/dotscope/src/compiler/codegen/tests.rs
@@ -1,7 +1,8 @@
 use crate::{
     analysis::{
-        ConstValue, DefSite, FieldRef, MethodRef, PhiNode, PhiOperand, SsaBlock, SsaFunction,
-        SsaFunctionBuilder, SsaInstruction, SsaOp, SsaType, SsaVarId, TypeRef, VariableOrigin,
+        BreakpointOp, ConstValue, DefSite, FieldRef, MethodRef, PhiNode, PhiOperand, SsaBlock,
+        SsaFunction, SsaFunctionBuilder, SsaInstruction, SsaOp, SsaType, SsaVarId, TypeRef,
+        VariableOrigin,
     },
     assembly::decode_stream,
     compiler::codegen::{SsaCodeGenerator, VarStorage},
@@ -919,7 +920,9 @@ fn test_nop_instruction() {
 fn test_break_instruction() {
     let mut ssa = SsaFunction::new(0, 0);
     let mut block = SsaBlock::new(0);
-    block.add_instruction(SsaInstruction::synthetic(SsaOp::Break));
+    block.add_instruction(SsaInstruction::synthetic(SsaOp::Break(
+        BreakpointOp::Breakpoint,
+    )));
     block.add_instruction(SsaInstruction::synthetic(SsaOp::Return { value: None }));
     ssa.add_block(block);
     assert_generates(&ssa, &["break", "ret"]);

--- a/dotscope/src/compiler/passes/constants/mod.rs
+++ b/dotscope/src/compiler/passes/constants/mod.rs
@@ -40,7 +40,7 @@ use analyssa::BitSet;
 use crate::{
     analysis::{
         conv_op_for_target, simplify_op, CilTarget, CmpKind, ConstValue, ConstValueCilExt,
-        ConstantPropagation, MethodRef, SccpResult, SimplifyResult, SsaCfg, SsaEvaluator,
+        ConstantPropagation, EhCfg, MethodRef, SccpResult, SimplifyResult, SsaEvaluator,
         SsaFunction, SsaOp, SsaType, SsaVarId,
     },
     compiler::{
@@ -281,8 +281,13 @@ impl ConstantPropagationPass {
         // which can cause SCCP to miss re-evaluating instructions when phi values change.
         ssa.recompute_uses();
 
-        // Build CFG from SSA and run SCCP analysis using the dataflow framework
-        let cfg = SsaCfg::from_ssa(ssa);
+        // Build CFG from SSA and run SCCP analysis using the dataflow framework.
+        //
+        // SCCP is rooted at the entry and walks forward, so it needs the
+        // exception-aware view: over terminator edges alone a handler block is
+        // unreachable, and every value defined in one would be left Top and
+        // folded as if it were a constant nobody wrote.
+        let cfg = EhCfg::from_ssa(ssa);
         let mut sccp = ConstantPropagation::new(ptr_size);
         let mut sccp_result = sccp.analyze(ssa, &cfg);
 
@@ -308,7 +313,7 @@ impl ConstantPropagationPass {
         );
         if constants.len() > pre_fold_count {
             ssa.recompute_uses();
-            let cfg = SsaCfg::from_ssa(ssa);
+            let cfg = EhCfg::from_ssa(ssa);
             let mut sccp2 = ConstantPropagation::new(ptr_size);
             let sccp_result2 = sccp2.analyze(ssa, &cfg);
             for (var, c) in sccp_result2.constants() {
@@ -1610,7 +1615,7 @@ impl ConstantPropagationPass {
         // trampoline may be threaded to the switch block itself. These
         // self-loops won't be caught by the higher-index scan below.
         if let Some(block) = ssa.block(block_idx) {
-            if let Some(op) = block.terminator_op() {
+            if let Some(op) = block.control_terminator() {
                 let self_targets = match op {
                     SsaOp::Switch {
                         targets, default, ..
@@ -1626,7 +1631,7 @@ impl ConstantPropagationPass {
         // Check for back-edges from blocks with higher indices.
         for bi in block_idx.saturating_add(1)..ssa.block_count() {
             if let Some(block) = ssa.block(bi) {
-                if let Some(op) = block.terminator_op() {
+                if let Some(op) = block.control_terminator() {
                     let targets_block = match op {
                         SsaOp::Jump { target } => *target == block_idx,
                         SsaOp::Leave { target } => *target == block_idx,
@@ -1679,7 +1684,7 @@ impl ConstantPropagationPass {
 
             // First pass: analyze the terminator without mutable borrow
             let simplification = if let Some(block) = ssa.block(block_idx) {
-                if let Some(op) = block.terminator_op() {
+                if let Some(op) = block.control_terminator() {
                     match op {
                         SsaOp::Branch {
                             condition,

--- a/dotscope/src/compiler/passes/constants/tests.rs
+++ b/dotscope/src/compiler/passes/constants/tests.rs
@@ -455,7 +455,7 @@ fn test_pass_branch_simplification() {
 
     // Check that branch was simplified to jump
     let block = ssa.block(0).unwrap();
-    if let Some(SsaOp::Jump { target }) = block.terminator_op() {
+    if let Some(SsaOp::Jump { target }) = block.control_terminator() {
         assert_eq!(*target, 1);
     } else {
         panic!("Expected Jump instruction");
@@ -488,7 +488,7 @@ fn test_pass_switch_simplification() {
 
     // Check that switch was simplified to jump to target 2 (index 1)
     let block = ssa.block(0).unwrap();
-    if let Some(SsaOp::Jump { target }) = block.terminator_op() {
+    if let Some(SsaOp::Jump { target }) = block.control_terminator() {
         assert_eq!(*target, 2);
     } else {
         panic!("Expected Jump instruction");
@@ -717,7 +717,7 @@ fn test_branch_false_condition() {
 
     // Check that branch was simplified to jump to false branch (target 2)
     let block = ssa.block(0).unwrap();
-    if let Some(SsaOp::Jump { target }) = block.terminator_op() {
+    if let Some(SsaOp::Jump { target }) = block.control_terminator() {
         assert_eq!(*target, 2);
     } else {
         panic!("Expected Jump instruction");
@@ -750,7 +750,7 @@ fn test_switch_out_of_range_uses_default() {
 
     // Check that switch was simplified to jump to default (target 4)
     let block = ssa.block(0).unwrap();
-    if let Some(SsaOp::Jump { target }) = block.terminator_op() {
+    if let Some(SsaOp::Jump { target }) = block.control_terminator() {
         assert_eq!(*target, 4);
     } else {
         panic!("Expected Jump instruction");

--- a/dotscope/src/compiler/passes/inlining.rs
+++ b/dotscope/src/compiler/passes/inlining.rs
@@ -633,10 +633,12 @@ impl<'a> InliningContext<'a> {
     ) -> SsaOp {
         let mut cloned = op.clone();
 
-        // Remap destination
-        if let Some(dest) = cloned.dest() {
-            let new_dest = Self::get_or_create_var(dest, var_remap, callee_ssa, caller_ssa);
-            cloned.set_dest(new_dest);
+        // Remap every definition, not just the primary destination: an operation
+        // with secondary or flag outputs defines those too, and a callee variable
+        // left unremapped would collide with the caller's numbering.
+        for def in op.defs() {
+            let new_def = Self::get_or_create_var(def, var_remap, callee_ssa, caller_ssa);
+            cloned.replace_def(def, new_def);
         }
 
         // Remap uses

--- a/dotscope/src/deobfuscation/passes/decryption.rs
+++ b/dotscope/src/deobfuscation/passes/decryption.rs
@@ -67,7 +67,7 @@ use std::{
 use analyssa::{
     graph::{
         algorithms::{compute_dominators, DominatorTree},
-        GraphBase, NodeId, RootedGraph,
+        GraphBase, NodeId,
     },
     ir::value::DecryptedArrayData,
 };
@@ -808,7 +808,7 @@ impl DecryptionPass {
     fn build_cfg_info(ssa: &SsaFunction) -> CfgInfoOwned {
         let cfg = SsaCfg::from_ssa(ssa);
         let node_count = cfg.node_count();
-        let entry = cfg.entry();
+        let entry = NodeId::new(0);
         let dom_tree = compute_dominators(&cfg, entry);
 
         let predecessors: Vec<Vec<usize>> = (0..node_count)

--- a/dotscope/src/deobfuscation/passes/opaquefields.rs
+++ b/dotscope/src/deobfuscation/passes/opaquefields.rs
@@ -457,7 +457,7 @@ impl SsaPass<CilTarget, CompilerContext> for OpaqueFieldPredicatePass {
         // Each entry: (block_idx, jump_target, dropped_target)
         let mut replacements: Vec<(usize, usize, usize)> = Vec::new();
         for (block_idx, block) in ssa.blocks().iter().enumerate() {
-            let Some(terminator) = block.terminator_op() else {
+            let Some(terminator) = block.control_terminator() else {
                 continue;
             };
 

--- a/dotscope/src/deobfuscation/passes/unflattening/detection.rs
+++ b/dotscope/src/deobfuscation/passes/unflattening/detection.rs
@@ -25,14 +25,14 @@ use std::{
 use analyssa::{
     graph::{
         algorithms::{compute_dominators, DominatorTree},
-        GraphBase, NodeId, Successors,
+        NodeId,
     },
     BitSet,
 };
 use rayon::prelude::*;
 
 use crate::{
-    analysis::{ControlFlow, SsaEvaluator, SsaFunction, SsaOp, SsaVarId, VariableOrigin},
+    analysis::{ControlFlow, SsaCfg, SsaEvaluator, SsaFunction, SsaOp, SsaVarId, VariableOrigin},
     deobfuscation::passes::unflattening::{
         dispatcher::{analyze_switch_dispatcher, Dispatcher, DispatcherInfo},
         statevar::{identify_state_variable, StateVariable},
@@ -143,39 +143,6 @@ impl EntryPoint {
     }
 }
 
-/// Adapter to use SsaFunction with graph algorithms.
-///
-/// This implements the `Successors` trait so we can compute dominators
-/// and other graph properties on the SSA CFG.
-struct SsaGraphAdapter<'a> {
-    ssa: &'a SsaFunction,
-}
-
-impl<'a> SsaGraphAdapter<'a> {
-    fn new(ssa: &'a SsaFunction) -> Self {
-        Self { ssa }
-    }
-}
-
-impl GraphBase for SsaGraphAdapter<'_> {
-    fn node_count(&self) -> usize {
-        self.ssa.block_count()
-    }
-
-    fn node_ids(&self) -> impl Iterator<Item = NodeId> {
-        (0..self.ssa.block_count()).map(NodeId::new)
-    }
-}
-
-impl Successors for SsaGraphAdapter<'_> {
-    fn successors(&self, node: NodeId) -> impl Iterator<Item = NodeId> {
-        self.ssa
-            .block_successors(node.index())
-            .into_iter()
-            .map(NodeId::new)
-    }
-}
-
 /// Detected CFF pattern with analysis metadata.
 #[derive(Debug, Clone)]
 pub struct CffPattern {
@@ -265,6 +232,10 @@ impl CffPattern {
 /// CFF detection engine.
 pub struct CffDetector<'a> {
     ssa: &'a SsaFunction,
+    /// The terminator-derived CFG relation. `SsaFunction` no longer answers
+    /// predecessor or successor questions itself, so the view is built once
+    /// here and shared by every query in this module.
+    cfg: SsaCfg<'a>,
     config: UnflattenConfig,
     /// Cached dominator tree (computed lazily)
     dom_tree: Option<DominatorTree>,
@@ -276,6 +247,7 @@ impl<'a> CffDetector<'a> {
     pub fn new(ssa: &'a SsaFunction) -> Self {
         Self {
             ssa,
+            cfg: SsaCfg::from_ssa(ssa),
             config: UnflattenConfig::default(),
             dom_tree: None,
         }
@@ -286,6 +258,7 @@ impl<'a> CffDetector<'a> {
     pub fn with_config(ssa: &'a SsaFunction, config: &UnflattenConfig) -> Self {
         Self {
             ssa,
+            cfg: SsaCfg::from_ssa(ssa),
             config: config.clone(),
             dom_tree: None,
         }
@@ -293,11 +266,8 @@ impl<'a> CffDetector<'a> {
 
     /// Gets or computes the dominator tree.
     fn get_dom_tree(&mut self) -> &DominatorTree {
-        let ssa = self.ssa;
-        self.dom_tree.get_or_insert_with(|| {
-            let adapter = SsaGraphAdapter::new(ssa);
-            compute_dominators(&adapter, NodeId::new(0))
-        })
+        let Self { cfg, dom_tree, .. } = self;
+        dom_tree.get_or_insert_with(|| compute_dominators(cfg, NodeId::new(0)))
     }
 
     /// Detects the best CFF dispatcher in the function.
@@ -555,16 +525,11 @@ impl<'a> CffDetector<'a> {
             }
 
             // Check predecessor count (should have many back edges).
-            // block_predecessors excludes self-loops, but a switch targeting itself
-            // is a valid CFF back-edge (e.g., x86-resolved CFF where case blocks
-            // were folded into the dispatcher). Count it separately.
-            let pred_count = self.ssa.block_predecessors(block_idx).len();
-            let has_self_loop = block
-                .instructions()
-                .iter()
-                .any(|i| i.op().successors().contains(&block_idx));
-            let effective_preds = pred_count.saturating_add(usize::from(has_self_loop));
-            return effective_preds >= 2;
+            // A switch targeting itself is a valid CFF back-edge (e.g.,
+            // x86-resolved CFF where case blocks were folded into the
+            // dispatcher); `SsaCfg` reports that self-edge like any other, so
+            // it needs no separate accounting.
+            return self.cfg.block_predecessors(block_idx).len() >= 2;
         }
 
         // Also consider blocks with conditional branches that could be if-else chains
@@ -574,7 +539,7 @@ impl<'a> CffDetector<'a> {
             .any(|instr| matches!(instr.op(), SsaOp::Branch { .. }));
 
         if has_branch {
-            let pred_count = self.ssa.block_predecessors(block_idx).len();
+            let pred_count = self.cfg.block_predecessors(block_idx).len();
             // If-else dispatchers typically have even more predecessors
             return pred_count >= 3;
         }
@@ -641,7 +606,7 @@ impl<'a> CffDetector<'a> {
 
         // Check successors of case blocks that don't go back to dispatcher
         for case_block in case_blocks.iter() {
-            for succ in self.ssa.block_successors(case_block) {
+            for &succ in self.cfg.block_successors(case_block) {
                 if succ != dispatcher_block && !case_blocks.contains(succ) {
                     exits.insert(succ);
                 }
@@ -653,11 +618,11 @@ impl<'a> CffDetector<'a> {
 
     /// Finds the entry block (predecessor of dispatcher that isn't a case block).
     fn find_entry_block(&self, dispatcher_block: usize) -> Option<usize> {
-        let preds = self.ssa.block_predecessors(dispatcher_block);
+        let preds = self.cfg.block_predecessors(dispatcher_block);
 
         // Entry block is typically block 0 or the first predecessor
         // that doesn't look like it came from a case block
-        for pred in preds {
+        for &pred in preds {
             if pred == 0 {
                 return Some(pred);
             }
@@ -683,7 +648,7 @@ impl<'a> CffDetector<'a> {
         state_var: Option<&StateVariable>,
     ) -> Vec<EntryPoint> {
         let mut entries = Vec::new();
-        let preds = self.ssa.block_predecessors(dispatcher_block);
+        let preds = self.cfg.block_predecessors(dispatcher_block);
 
         // Collect non-case-block predecessors as potential entry points
         let entry_blocks: Vec<usize> = preds
@@ -951,9 +916,9 @@ impl<'a> CffDetector<'a> {
         _all_entries: &[usize],
     ) -> Option<EntryCondition> {
         // Look for blocks that branch to this entry
-        let preds = self.ssa.block_predecessors(entry_block);
+        let preds = self.cfg.block_predecessors(entry_block);
 
-        for pred in preds {
+        for &pred in preds {
             let Some(pred_block) = self.ssa.block(pred) else {
                 continue;
             };
@@ -1053,7 +1018,7 @@ impl<'a> CffDetector<'a> {
         }
 
         // Signal 3: Dispatcher has many predecessors (back edges)
-        let pred_count = ssa.block_predecessors(dispatcher_block).len();
+        let pred_count = self.cfg.block_predecessors(dispatcher_block).len();
         if pred_count >= case_count / 2 {
             score += w.predecessor_ratio;
         }
@@ -1069,7 +1034,7 @@ impl<'a> CffDetector<'a> {
             .iter()
             .filter(|&b| {
                 can_reach_dispatcher(
-                    ssa,
+                    &self.cfg,
                     b,
                     dispatcher_block,
                     dispatcher_node,
@@ -1139,7 +1104,7 @@ impl<'a> CffDetector<'a> {
 /// blocks) before eventually reaching the dispatcher. This function does
 /// bounded BFS to detect these transitive paths.
 fn can_reach_dispatcher(
-    ssa: &SsaFunction,
+    cfg: &SsaCfg,
     from: usize,
     dispatcher_block: usize,
     dispatcher_node: NodeId,
@@ -1147,14 +1112,14 @@ fn can_reach_dispatcher(
     max_depth: usize,
 ) -> bool {
     // Direct check first (fast path)
-    if ssa.block_successors(from).contains(&dispatcher_block) {
+    if cfg.block_successors(from).contains(&dispatcher_block) {
         return true;
     }
 
     let mut queue = VecDeque::new();
-    let mut visited = BitSet::new(ssa.block_count());
+    let mut visited = BitSet::new(cfg.block_count());
 
-    for succ in ssa.block_successors(from) {
+    for &succ in cfg.block_successors(from) {
         if succ != from {
             queue.push_back((succ, 1));
         }
@@ -1172,7 +1137,7 @@ fn can_reach_dispatcher(
         if !dom_tree.dominates(dispatcher_node, NodeId::new(block)) {
             continue;
         }
-        for succ in ssa.block_successors(block) {
+        for &succ in cfg.block_successors(block) {
             if !visited.contains(succ) {
                 queue.push_back((succ, depth.saturating_add(1)));
             }

--- a/dotscope/src/deobfuscation/passes/unflattening/resolve.rs
+++ b/dotscope/src/deobfuscation/passes/unflattening/resolve.rs
@@ -47,7 +47,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use rustc_hash::FxHashMap;
 
 use crate::{
-    analysis::{CmpKind, ConstValue, PhiNode, SsaFunction, SsaInstruction, SsaOp, SsaVarId},
+    analysis::{
+        CmpKind, ConstValue, PhiNode, SsaCfg, SsaFunction, SsaInstruction, SsaOp, SsaVarId,
+    },
     deobfuscation::passes::unflattening::dispatcher::Dispatcher,
 };
 
@@ -219,7 +221,7 @@ impl DispatchTable {
                 true_target,
                 false_target,
                 ..
-            }) = block.terminator_op()
+            }) = block.control_terminator()
             else {
                 self.fallthrough = Some(current);
                 return;
@@ -951,7 +953,7 @@ fn region_from(ssa: &SsaFunction, start: usize, stop: usize, budget: usize) -> B
         if seen.len() > budget {
             break;
         }
-        if let Some(op) = ssa.block(current).and_then(|b| b.terminator_op()) {
+        if let Some(op) = ssa.block(current).and_then(|b| b.control_terminator()) {
             frontier.extend(op.successors());
         }
     }
@@ -973,7 +975,9 @@ pub fn resolve_dispatch_edges(
         // Without a state phi there is nothing per-edge to read: the switch
         // operand is computed inside the dispatcher from something that is not
         // merged at its entry.
-        stats.unresolved = ssa.block_predecessors(dispatcher.block).len();
+        stats.unresolved = SsaCfg::from_ssa(ssa)
+            .block_predecessors(dispatcher.block)
+            .len();
         return (Vec::new(), stats);
     };
 
@@ -1421,9 +1425,8 @@ pub fn clear_unreachable(ssa: &mut SsaFunction) -> usize {
 
     let mut roots: Vec<usize> = vec![0];
     for handler in ssa.exception_handlers() {
-        roots.extend(handler.handler_start_block);
-        roots.extend(handler.filter_start_block);
-        roots.extend(handler.try_start_block);
+        roots.extend(handler.entry_blocks());
+        roots.extend(handler.protected_range.map(|range| range.start()));
     }
 
     let mut reachable = vec![false; block_count];
@@ -1436,7 +1439,7 @@ pub fn clear_unreachable(ssa: &mut SsaFunction) -> usize {
             continue;
         }
         *slot = true;
-        if let Some(op) = ssa.block(current).and_then(|b| b.terminator_op()) {
+        if let Some(op) = ssa.block(current).and_then(|b| b.control_terminator()) {
             frontier.extend(op.successors());
         }
     }
@@ -1657,7 +1660,7 @@ mod tests {
 
         assert_eq!(apply_rewires(&mut ssa, &rewires), 2);
         assert!(
-            ssa.block_predecessors(2).is_empty(),
+            SsaCfg::from_ssa(&ssa).block_predecessors(2).is_empty(),
             "no edge should still reach the dispatcher"
         );
 
@@ -1701,7 +1704,7 @@ mod tests {
         for rewire in &rewires {
             let successors = ssa
                 .block(rewire.from)
-                .and_then(|b| b.terminator_op())
+                .and_then(|b| b.control_terminator())
                 .map(SsaOp::successors)
                 .unwrap_or_default();
             assert!(
@@ -1765,8 +1768,8 @@ mod tests {
 
         apply_rewires(&mut ssa, &rewires);
         assert_eq!(
-            ssa.block_predecessors(2),
-            vec![0],
+            SsaCfg::from_ssa(&ssa).block_predecessors(2),
+            [0],
             "the unresolved edge keeps using the dispatcher"
         );
         assert_eq!(

--- a/dotscope/src/deobfuscation/renamer/phases.rs
+++ b/dotscope/src/deobfuscation/renamer/phases.rs
@@ -473,10 +473,10 @@ fn find_phase_boundaries(ssa: &SsaFunction, assembly: &CilObject) -> (Vec<usize>
 
     // Exception handler entries are phase boundaries
     for handler in ssa.exception_handlers() {
-        if let Some(handler_start) = handler.handler_start_block {
+        if let Some(handler_start) = handler.handler_range.map(|range| range.start()) {
             boundaries.insert(handler_start);
         }
-        if let Some(try_start) = handler.try_start_block {
+        if let Some(try_start) = handler.protected_range.map(|range| range.start()) {
             boundaries.insert(try_start);
         }
     }
@@ -556,7 +556,7 @@ fn build_phases_from_boundaries(
 
         // Check if this range is an exception handler
         for handler in ssa.exception_handlers() {
-            if handler.handler_start_block == Some(start) {
+            if handler.handler_range.map(|range| range.start()) == Some(start) {
                 structure = Some("try/catch".to_string());
             }
         }

--- a/dotscope/src/deobfuscation/techniques/generic/opaquefields.rs
+++ b/dotscope/src/deobfuscation/techniques/generic/opaquefields.rs
@@ -77,7 +77,7 @@ fn collect_predicate_static_fields(ssa: &SsaFunction) -> HashSet<Token> {
 
     let mut static_fields = HashSet::new();
     for block in ssa.blocks() {
-        let Some(terminator) = block.terminator_op() else {
+        let Some(terminator) = block.control_terminator() else {
             continue;
         };
 
@@ -257,7 +257,7 @@ fn identify_sentinel_method(ssa: &SsaFunction) -> Option<Token> {
     let block = ssa.blocks().first()?;
 
     // Find the Return terminator
-    let terminator = block.terminator_op()?;
+    let terminator = block.control_terminator()?;
     let return_var = match terminator {
         SsaOp::Return { value: Some(v) } => *v,
         _ => return None,

--- a/dotscope/src/emulation/runtime/bcl/text/encoding.rs
+++ b/dotscope/src/emulation/runtime/bcl/text/encoding.rs
@@ -887,8 +887,10 @@ fn unicode_get_string_pre(ctx: &HookContext<'_>, thread: &mut EmulationThread) -
             }
 
             let u16s: Vec<u16> = bytes
-                .chunks_exact(2)
-                .filter_map(|chunk| <[u8; 2]>::try_from(chunk).ok())
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .copied()
                 .map(u16::from_le_bytes)
                 .collect();
 
@@ -962,8 +964,10 @@ fn decode_bytes(bytes: &[u8], encoding_type: EncodingType) -> String {
                 return String::new();
             }
             let u16s: Vec<u16> = bytes
-                .chunks_exact(2)
-                .filter_map(|chunk| <[u8; 2]>::try_from(chunk).ok())
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .copied()
                 .map(u16::from_le_bytes)
                 .collect();
             String::from_utf16_lossy(&u16s)
@@ -973,8 +977,10 @@ fn decode_bytes(bytes: &[u8], encoding_type: EncodingType) -> String {
                 return String::new();
             }
             let u16s: Vec<u16> = bytes
-                .chunks_exact(2)
-                .filter_map(|chunk| <[u8; 2]>::try_from(chunk).ok())
+                .as_chunks::<2>()
+                .0
+                .iter()
+                .copied()
                 .map(u16::from_be_bytes)
                 .collect();
             String::from_utf16_lossy(&u16s)
@@ -984,8 +990,10 @@ fn decode_bytes(bytes: &[u8], encoding_type: EncodingType) -> String {
                 return String::new();
             }
             bytes
-                .chunks_exact(4)
-                .filter_map(|chunk| <[u8; 4]>::try_from(chunk).ok())
+                .as_chunks::<4>()
+                .0
+                .iter()
+                .copied()
                 .map(u32::from_le_bytes)
                 .filter_map(char::from_u32)
                 .collect()

--- a/dotscope/src/emulation/value/emvalue.rs
+++ b/dotscope/src/emulation/value/emvalue.rs
@@ -766,6 +766,8 @@ impl From<&ConstValue> for EmValue {
     #[allow(clippy::cast_possible_wrap)] // U32->I32 and U64->I64 are intentional bit-preserving casts
     fn from(value: &ConstValue) -> Self {
         match value {
+            // Uninhabited for this target: CIL has no symbol space.
+            ConstValue::Symbol(symbol) => match *symbol {},
             // Signed integers - promote small types to I32 using infallible From
             ConstValue::I8(v) => EmValue::I32(i32::from(*v)),
             ConstValue::I16(v) => EmValue::I32(i32::from(*v)),

--- a/dotscope/src/file/mod.rs
+++ b/dotscope/src/file/mod.rs
@@ -125,7 +125,7 @@ pub mod repair;
 use std::path::Path;
 
 use cowfile::CowFile;
-use goblin::pe::PE;
+use goblin::pe::{options::ParseOptions, PE};
 use pe::{DataDirectory, DataDirectoryType, Pe};
 
 use crate::{
@@ -395,7 +395,18 @@ impl File {
             cowfile.commit()?;
         }
 
-        let goblin_pe = PE::parse(cowfile.data()).map_err(Error::from)?;
+        // Resources are parsed off. Nothing here reads them: `Pe::from_goblin_pe`
+        // takes the headers, sections, imports, exports, libraries and data
+        // directories, and a .NET assembly's own resources live in the managed
+        // metadata (`ManifestResource` / the `.resources` streams), not in the
+        // PE resource directory. What the directory does hold for an assembly is
+        // `VS_VERSIONINFO`, dialogs and string tables — and goblin walks that
+        // tree in `ParseMode::Strict` by default, so one malformed
+        // `ResourceString` in any of it aborts the whole parse and takes every
+        // bit of CIL metadata with it. The relocation-side directory walk this
+        // crate needs is its own, in `file::pe`.
+        let opts = ParseOptions::default().with_parse_resources(false);
+        let goblin_pe = PE::parse_with_opts(cowfile.data(), &opts).map_err(Error::from)?;
         let pe = Pe::from_goblin_pe(&goblin_pe)?;
 
         Ok(File {

--- a/dotscope/src/metadata/method/mod.rs
+++ b/dotscope/src/metadata/method/mod.rs
@@ -109,7 +109,9 @@ pub use iter::InstructionIterator;
 pub use types::*;
 
 use crate::{
-    analysis::{ControlFlowGraph, SsaConverter, SsaExceptionHandler, SsaFunction, TypeContext},
+    analysis::{
+        BlockRange, ControlFlowGraph, SsaConverter, SsaExceptionHandler, SsaFunction, TypeContext,
+    },
     assembly::{self, BasicBlock, InstructionEncoder},
     file::File,
     metadata::{
@@ -1644,14 +1646,14 @@ impl Method {
 
                     // Map offsets to block indices (add base_offset to convert relative to absolute)
                     let try_start_block = Self::find_block_at_offset(blocks, try_offset_abs);
-                    let try_end_block = Self::find_block_at_offset(blocks, try_end_abs);
+                    let try_end_block = Self::find_region_end_block(blocks, try_end_abs);
 
-                    // For handler blocks, use the handler_entry info from decoder if available
-                    let handler_start_block = Self::find_handler_entry_block(blocks, handler_idx)
-                        .or_else(|| Self::find_block_at_offset(blocks, handler_offset_abs));
-                    let handler_end_block = Self::find_block_at_offset(blocks, handler_end_abs);
-
-                    let filter_start_block = if eh.flags == ExceptionHandlerFlags::FILTER {
+                    // The filter expression is resolved first because the handler's own
+                    // start depends on it: the decoder marks the filter's entry block with
+                    // the same handler index as the handler body's, and the filter comes
+                    // first in layout order, so a search by index alone answers with the
+                    // filter block for every filter clause.
+                    let filter_start_block = if eh.flags.kind() == ExceptionHandlerKind::Filter {
                         let filter_offset_abs = base_offset
                             .checked_add(eh.filter_offset as usize)
                             .ok_or_else(|| {
@@ -1662,13 +1664,26 @@ impl Method {
                         None
                     };
 
+                    // For handler blocks, use the handler_entry info from decoder if available
+                    let handler_start_block =
+                        Self::find_handler_entry_block(blocks, handler_idx, filter_start_block)
+                            .or_else(|| Self::find_block_at_offset(blocks, handler_offset_abs));
+                    let handler_end_block = Self::find_region_end_block(blocks, handler_end_abs);
+
                     // Get the class token for catch handlers
-                    let class_token_or_filter = if eh.flags == ExceptionHandlerFlags::EXCEPTION {
-                        eh.handler.as_ref().map_or(0, |t| t.token.value())
-                    } else if eh.flags == ExceptionHandlerFlags::FILTER {
-                        eh.filter_offset
-                    } else {
-                        0
+                    let class_token_or_filter = match eh.flags.kind() {
+                        ExceptionHandlerKind::Catch => {
+                            eh.handler.as_ref().map_or(0, |t| t.token.value())
+                        }
+                        ExceptionHandlerKind::Filter => eh.filter_offset,
+                        ExceptionHandlerKind::Finally | ExceptionHandlerKind::Fault => 0,
+                    };
+
+                    // Each part is a half-open block range or nothing at all: a start
+                    // without an end never described a region anyone could regenerate an
+                    // IL table from, and `BlockRange` makes that state unrepresentable.
+                    let range = |start: Option<usize>, end: Option<usize>| {
+                        start.zip(end).and_then(|(s, e)| BlockRange::new(s, e))
                     };
 
                     ssa_handlers.push(SsaExceptionHandler {
@@ -1678,11 +1693,15 @@ impl Method {
                         handler_offset: eh.handler_offset,
                         handler_length: eh.handler_length,
                         class_token_or_filter,
-                        try_start_block,
-                        try_end_block,
-                        handler_start_block,
-                        handler_end_block,
-                        filter_start_block,
+                        protected_range: range(try_start_block, try_end_block),
+                        handler_range: range(handler_start_block, handler_end_block),
+                        // A CIL filter expression occupies [filter_offset, handler_offset),
+                        // so its exclusive end is wherever the handler begins. Taking the
+                        // handler's resolved start rather than re-deriving one from
+                        // `handler_offset_abs` keeps the two parts from claiming the same
+                        // block when the decoder's marker and the IL offset disagree — an
+                        // overlap analyssa reports as a malformed clause.
+                        filter_range: range(filter_start_block, handler_start_block),
                     });
                 }
 
@@ -1759,12 +1778,39 @@ impl Method {
             .position(|b| offset >= b.offset && offset < b.offset.saturating_add(b.size))
     }
 
+    /// Finds the exclusive end block of a region ending at `offset`.
+    ///
+    /// `offset` is one past the region's last IL byte, so the answer is the block
+    /// that begins there. A region running to the end of the method body has no
+    /// such block; its exclusive end is one past the last block, which is what
+    /// distinguishes "the region ends with the method" from "the region's end
+    /// could not be mapped at all".
+    fn find_region_end_block(blocks: &[BasicBlock], offset: usize) -> Option<usize> {
+        if let Some(idx) = Self::find_block_at_offset(blocks, offset) {
+            return Some(idx);
+        }
+
+        let body_end = blocks.last().map_or(0, |b| b.offset.saturating_add(b.size));
+        (offset >= body_end).then_some(blocks.len())
+    }
+
     /// Finds the block that is marked as an entry point for the given handler index.
-    fn find_handler_entry_block(blocks: &[BasicBlock], handler_index: usize) -> Option<usize> {
-        blocks.iter().position(|b| {
-            b.handler_entry
+    ///
+    /// A filter clause marks two blocks with the same handler index — the filter
+    /// expression's entry and the handler body's — and the filter is laid out
+    /// first, so `filter_block` names the one to skip. Without it the handler
+    /// body of every filter clause would resolve to its filter expression.
+    fn find_handler_entry_block(
+        blocks: &[BasicBlock],
+        handler_index: usize,
+        filter_block: Option<usize>,
+    ) -> Option<usize> {
+        blocks.iter().enumerate().find_map(|(idx, b)| {
+            let marks_this_handler = b
+                .handler_entry
                 .as_ref()
-                .is_some_and(|info| info.handler_index == handler_index)
+                .is_some_and(|info| info.handler_index == handler_index);
+            (marks_this_handler && Some(idx) != filter_block).then_some(idx)
         })
     }
 

--- a/dotscope/src/metadata/security/permissionset.rs
+++ b/dotscope/src/metadata/security/permissionset.rs
@@ -703,10 +703,10 @@ impl PermissionSet {
         loop {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(ref e)) => match e.name().as_ref() {
-                    b"PermissionSet" => {
+                    "PermissionSet" => {
                         in_permission_set = true;
                     }
-                    b"IPermission" if in_permission_set => {
+                    "IPermission" if in_permission_set => {
                         permissions
                             .push(Self::parse_permission_from_xml_attributes(e.attributes())?);
                     }
@@ -714,11 +714,11 @@ impl PermissionSet {
                 },
                 // Handle self-closing tags like <IPermission ... />
                 Ok(Event::Empty(ref e))
-                    if e.name().as_ref() == b"IPermission" && in_permission_set =>
+                    if e.name().as_ref() == "IPermission" && in_permission_set =>
                 {
                     permissions.push(Self::parse_permission_from_xml_attributes(e.attributes())?);
                 }
-                Ok(Event::End(ref e)) if e.name().as_ref() == b"PermissionSet" => {
+                Ok(Event::End(ref e)) if e.name().as_ref() == "PermissionSet" => {
                     in_permission_set = false;
                 }
                 Ok(Event::Eof) => break,
@@ -742,10 +742,8 @@ impl PermissionSet {
         for attr_result in attributes {
             let attr = attr_result.map_err(|e| malformed_error!("Invalid XML attribute: {}", e))?;
 
-            let key = std::str::from_utf8(attr.key.as_ref())
-                .map_err(|_| malformed_error!("Invalid UTF-8 in XML attribute key"))?;
-            let value = std::str::from_utf8(&attr.value)
-                .map_err(|_| malformed_error!("Invalid UTF-8 in XML attribute value"))?;
+            let key = attr.key.as_ref();
+            let value = attr.value.as_ref();
 
             match key {
                 "class" => class_name = value.to_string(),

--- a/dotscope/src/metadata/streams/userstrings.rs
+++ b/dotscope/src/metadata/streams/userstrings.rs
@@ -230,13 +230,15 @@ impl<'a> UserStrings<'a> {
         // hardware behaves. It also reads native-endian, while ECMA-335 §II.24.2.4 specifies
         // little-endian, so the same input would decode differently on a big-endian target.
         //
-        // `utf16_data.len()` is even (rejected above otherwise), so `chunks_exact(2)` consumes it
-        // fully with no remainder.
+        // `utf16_data.len()` is even (rejected above otherwise), so `as_chunks::<2>` consumes it
+        // fully and its remainder is empty. It yields the two-byte arrays themselves, so there is
+        // no fallible conversion and no indexing that could panic.
         let code_units: Vec<u16> = utf16_data
-            .chunks_exact(2)
-            // `chunks_exact(2)` yields only two-byte chunks, so the conversion cannot fail; the
-            // fallback exists so this stays free of indexing that could panic.
-            .map(|pair| <[u8; 2]>::try_from(pair).map_or(0, u16::from_le_bytes))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .copied()
+            .map(u16::from_le_bytes)
             .collect();
 
         Ok(U16String::from_vec(code_units))

--- a/dotscope/src/metadata/typesystem/primitives.rs
+++ b/dotscope/src/metadata/typesystem/primitives.rs
@@ -451,12 +451,16 @@ impl CilPrimitiveData {
                     .into());
                 }
 
-                let mut utf16_chars: Vec<u16> = Vec::with_capacity(data.len() / 2);
-                for chunk in data.chunks_exact(2) {
-                    let b0 = *chunk.first().ok_or(primitives_oob())?;
-                    let b1 = *chunk.get(1).ok_or(primitives_oob())?;
-                    utf16_chars.push(u16::from_le_bytes([b0, b1]));
-                }
+                // `data.len()` is even (rejected above otherwise), so `as_chunks::<2>`
+                // consumes it fully. It yields the two-byte arrays themselves, so the
+                // per-byte bounds checks the pair used to need are gone with them.
+                let utf16_chars: Vec<u16> = data
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
+                    .copied()
+                    .map(u16::from_le_bytes)
+                    .collect();
 
                 match String::from_utf16(&utf16_chars) {
                     Ok(utf_string) => Ok(CilPrimitiveData::String(utf_string)),

--- a/dotscope/src/utils/io.rs
+++ b/dotscope/src/utils/io.rs
@@ -1229,9 +1229,11 @@ pub fn write_prefixed_string_utf16(value: &str, buffer: &mut Vec<u8>) {
 #[must_use]
 pub fn decode_utf16le(bytes: &[u8]) -> Option<String> {
     let mut utf16_chars = Vec::new();
-    for pair in bytes.chunks_exact(2) {
-        let arr: [u8; 2] = pair.try_into().ok()?;
-        let ch = u16::from_le_bytes(arr);
+    // `as_chunks` hands back the two-byte arrays themselves, so there is no
+    // fallible conversion to answer for; a trailing odd byte lands in the
+    // remainder, which a UTF-16 unit cannot be built from anyway.
+    for &pair in bytes.as_chunks::<2>().0 {
+        let ch = u16::from_le_bytes(pair);
         if ch == 0 {
             break;
         }

--- a/dotscope/tests/ssa.rs
+++ b/dotscope/tests/ssa.rs
@@ -24,8 +24,8 @@ use std::collections::HashMap;
 use common::{build_cfg, build_ssa, TestTypeProvider};
 use dotscope::{
     analysis::{
-        ConstValue, ControlFlowGraph, SsaConverter, SsaExceptionHandler, SsaExceptionHandlerCilExt,
-        SsaFunction, SsaOp, SsaVarId, SymbolicEvaluator, SymbolicExpr,
+        BlockRange, ConstValue, ControlFlowGraph, SsaConverter, SsaExceptionHandler,
+        SsaExceptionHandlerCilExt, SsaFunction, SsaOp, SsaVarId, SymbolicEvaluator, SymbolicExpr,
     },
     assembly::{decode_blocks, InstructionAssembler},
     metadata::{
@@ -2110,11 +2110,9 @@ fn test_ssa_exception_handler_preservation() -> Result<()> {
             handler_offset: handler.handler_offset,
             handler_length: handler.handler_length,
             class_token_or_filter: handler.filter_offset,
-            try_start_block: Some(0),
-            try_end_block: Some(1),
-            handler_start_block: Some(1),
-            handler_end_block: Some(2),
-            filter_start_block: None,
+            protected_range: BlockRange::new(0, 1),
+            handler_range: BlockRange::new(1, 2),
+            filter_range: None,
         };
         ssa.set_exception_handlers(vec![ssa_handler]);
     }
@@ -2132,8 +2130,8 @@ fn test_ssa_exception_handler_preservation() -> Result<()> {
 
     let eh = &ssa.exception_handlers()[0];
     assert_eq!(eh.flags, ExceptionHandlerFlags::EXCEPTION);
-    assert_eq!(eh.try_start_block, Some(0));
-    assert_eq!(eh.handler_start_block, Some(1));
+    assert_eq!(eh.protected_range.map(|range| range.start()), Some(0));
+    assert_eq!(eh.handler_range.map(|range| range.start()), Some(1));
     assert!(
         eh.has_block_mapping(),
         "Handler should have block mapping set"
@@ -2186,11 +2184,9 @@ fn test_ssa_finally_handler() -> Result<()> {
             handler_offset: handler.handler_offset,
             handler_length: handler.handler_length,
             class_token_or_filter: handler.filter_offset,
-            try_start_block: Some(0),
-            try_end_block: Some(1),
-            handler_start_block: Some(1),
-            handler_end_block: Some(2),
-            filter_start_block: None,
+            protected_range: BlockRange::new(0, 1),
+            handler_range: BlockRange::new(1, 2),
+            filter_range: None,
         };
         ssa.set_exception_handlers(vec![ssa_handler]);
     }
@@ -2262,11 +2258,9 @@ fn test_ssa_nested_exception_handlers() -> Result<()> {
             handler_offset: handler.handler_offset,
             handler_length: handler.handler_length,
             class_token_or_filter: handler.filter_offset,
-            try_start_block: Some(i),
-            try_end_block: Some(i + 1),
-            handler_start_block: Some(i + 1),
-            handler_end_block: Some(i + 2),
-            filter_start_block: None,
+            protected_range: BlockRange::new(i, i + 1),
+            handler_range: BlockRange::new(i + 1, i + 2),
+            filter_range: None,
         };
         ssa_handlers.push(ssa_handler);
     }
@@ -2367,16 +2361,16 @@ fn test_ssa_pipeline_preserves_exception_handlers() {
                         i, method.name
                     );
 
-                    // Verify block indices are set (not None)
+                    // Verify block ranges are set (not None)
                     assert!(
-                        ssa_eh.try_start_block.is_some(),
-                        "Handler {} try_start_block should be mapped in '{}'",
+                        ssa_eh.protected_range.is_some(),
+                        "Handler {} protected_range should be mapped in '{}'",
                         i,
                         method.name
                     );
                     assert!(
-                        ssa_eh.handler_start_block.is_some(),
-                        "Handler {} handler_start_block should be mapped in '{}'",
+                        ssa_eh.handler_range.is_some(),
+                        "Handler {} handler_range should be mapped in '{}'",
                         i,
                         method.name
                     );
@@ -2457,14 +2451,14 @@ fn test_decrypt_secret_handler_content() {
                 println!("\nException handlers:");
                 for (i, eh) in ssa.exception_handlers().iter().enumerate() {
                     println!(
-                        "  EH {}: flags={:?}, try_start={:?}, handler_start={:?}",
-                        i, eh.flags, eh.try_start_block, eh.handler_start_block
+                        "  EH {}: flags={:?}, protected={:?}, handler={:?}",
+                        i, eh.flags, eh.protected_range, eh.handler_range
                     );
                 }
 
                 // Verify handler block has content
                 if let Some(eh) = ssa.exception_handlers().first() {
-                    if let Some(handler_block_idx) = eh.handler_start_block {
+                    if let Some(handler_block_idx) = eh.handler_range.map(|range| range.start()) {
                         let handler_block = ssa
                             .block(handler_block_idx)
                             .expect("Handler block should exist");
@@ -2554,16 +2548,16 @@ fn test_try_region_block_decoding() {
 
             let ssa_eh = &ssa.exception_handlers()[0];
             assert!(
-                ssa_eh.try_start_block.is_some(),
-                "Try start block should be mapped"
+                ssa_eh.protected_range.is_some(),
+                "Protected range should be mapped"
             );
             assert!(
-                ssa_eh.handler_start_block.is_some(),
-                "Handler start block should be mapped"
+                ssa_eh.handler_range.is_some(),
+                "Handler range should be mapped"
             );
 
             // Verify try block has actual content
-            if let Some(try_start) = ssa_eh.try_start_block {
+            if let Some(try_start) = ssa_eh.protected_range.map(|range| range.start()) {
                 let try_block = ssa.block(try_start).expect("Try block should exist");
                 assert!(
                     !try_block.instructions().is_empty(),


### PR DESCRIPTION
A dependency release, and the defects that adopting the dependency exposed.
analyssa 0.6.0 reshapes how an exception clause is represented and takes away
the CFG relations `SsaFunction` used to answer itself — which forced every
analysis to say which graph it wanted, and three of them turned out to have been
reading one that contains no handlers. The rest of the set shares that shape: an
exception clause read through fields that could not say what the clause meant.

### Fixed

- **Liveness ran over a graph in which no handler is reachable.** The local
  coalescer built its dataflow CFG from terminator edges alone, and nothing
  branches to a handler entry — the runtime dispatches into it. A variable live
  only across a protected region therefore came back dead, and the coalescer was
  free to give its slot to something else. It now solves over the
  exception-aware view; the extra edges only widen liveness, which is a
  may-analysis, so nothing that was correct becomes wrong.

- **SCCP folded values defined in handlers as constants nobody wrote.** The same
  graph, the same reason, the opposite direction: constant propagation is rooted
  at the entry and walks forward, so a handler block was simply never visited
  and every value defined in one stayed at `Top` — the lattice element meaning
  "no definition has reached this yet", which the fold reads as a constant. Both
  SCCP rounds now run over the exception-aware view.

- **A filter clause's handler body resolved to its filter expression.** The
  decoder marks the filter's entry block and the handler body's entry block with
  the same handler index, and the filter is laid out first, so the search that
  took the first match answered with the filter block for every `catch … when`
  clause — a wrong `handler_offset` in the regenerated exception table. The
  filter is now resolved first and excluded from the handler's own search.

- **Full inlining remapped only an operation's primary destination.** An
  operation defining a secondary or flag output would have carried the callee's
  variable id for it into the caller, where it means something else. Latent for
  a CIL front-end, whose operations define one variable each, and repaired
  rather than left to a future one: every definition the operand walk reports is
  now remapped. That disagreement is why analyssa removed the
  single-destination setter this used.

- **One malformed PE resource discarded an assembly's entire metadata.** goblin
  walks the resource directory in strict mode by default, so a single bad
  `ResourceString` in a `VS_VERSIONINFO` block aborted the whole PE parse and
  took every byte of CIL metadata with it. Nothing in dotscope reads that
  directory — a .NET assembly's own resources live in the managed metadata — so
  it is no longer parsed.

- **CFF dispatcher detection counted a self-loop by hand.** It compensated for a
  predecessor relation that dropped self-edges by scanning the block's
  instructions for one. The relation it now asks reports a self-edge like any
  other, so the compensation is gone and predecessor counts agree with what phi
  validation sees.

### Changed

- **BREAKING**: **An exception clause is three optional block ranges, not five
  loose block indices.** `SsaExceptionHandler` carries `protected_range`,
  `handler_range` and `filter_range` — each a half-open `BlockRange` or nothing —
  in place of `try_start_block`, `try_end_block`, `handler_start_block`,
  `handler_end_block` and `filter_start_block`. A part can no longer be half of
  itself: a region that began somewhere and ended nowhere was a state the old
  five fields could hold and no check could refuse.

  A CIL filter's extent is now recorded rather than inferred. It is
  `[filter_offset, handler_offset)` — the blocks between the filter's entry and
  the handler's — so a filter clause finally says where its expression is
  instead of leaving every reader to guess it from the neighbouring parts.

  `BlockRange`, `ClausePart`, `ClauseLayout`, `LaidOutHandler`, `HandlerKind`,
  `ExceptionBlocks` and `ExceptionTableError` are re-exported from
  `dotscope::analysis`, so a caller holding a dotscope exception handler has the
  vocabulary it answers in without naming analyssa.

- **BREAKING**: **`SsaBlock::terminator_op` is `SsaBlock::control_terminator`.**
  The old name was positional — the block's last instruction, whatever it was —
  while every call site was asking a control-flow question. The rename is
  analyssa's; dotscope's call sites now ask the control question, so a block
  whose last instruction is not a terminator contributes no edges rather than
  edges leaving from an instruction control cannot reach.

- **BREAKING**: **`SsaFunction` no longer answers predecessor or successor
  questions.** `block_predecessors` and `block_successors` are gone;
  `SsaCfg::from_ssa` is the terminator-derived relation and `EhCfg::from_ssa`
  the exception-aware one, and which one an analysis needs is now a decision it
  has to state.

- **BREAKING**: **`SsaOp::Break` carries a `BreakpointOp`.** CIL `break` is
  `SsaOp::Break(BreakpointOp::Breakpoint)`. `BreakpointOp` is re-exported from
  `dotscope::analysis`.

- **BREAKING**: **`ConstValue` gained a `Symbol` variant, so exhaustive matches
  on it need one more arm.** CIL has no symbol space — every entity is named by
  a metadata token that the type, method and field references already carry — so
  `CilTarget::SymbolRef` is an uninhabited type and the arm is unreachable by
  construction.

- **`Target::handler_kind` replaces `Target::is_filter_handler`.** `CilTarget`
  classifies through the existing `ExceptionHandlerFlags::kind`, so the
  ECMA-335 §II.25.4.6 bit classification has one definition in the crate rather
  than two that can disagree.

- **UTF-16 and UTF-32 decoding takes the chunks as arrays.** Seven sites cut a
  byte slice into fixed-width units by hand: six paired `chunks_exact(N)` with a
  fallible conversion back to `[u8; N]`, and one indexed the chunk byte by byte.
  Each carried a fallback for a case that cannot arise — a dropped code unit, a
  zero, an error return. `as_chunks` yields the arrays themselves, so the
  fallbacks and the bounds checks are gone with them.

### Dependencies

- `analyssa` 0.5.0 → 0.6.0
- `quick-xml` 0.41.0 → 0.42.0. Element names and attribute keys are `&str`
  rather than `&[u8]`, so `PermissionSet`'s XML reader compares them directly
  instead of decoding each one and reporting a UTF-8 error the parser has
  already ruled out.
- `z3` 0.20.2 → 0.21.0
